### PR TITLE
Fixes .com// in public api url and updates query_hash's for user_following_gql_chunk and user_followers_gql_chunk

### DIFF
--- a/instagrapi/mixins/public.py
+++ b/instagrapi/mixins/public.py
@@ -205,7 +205,9 @@ class PublicRequestMixin:
             self.last_response_ts = time.time()
 
     def public_a1_request(self, endpoint, data=None, params=None, headers=None):
-        url = self.PUBLIC_API_URL + endpoint  # (jarrodnorwell) fixed KeyError: 'data'
+        url = (self.PUBLIC_API_URL + str(endpoint)).replace(
+            ".com//", ".com/"
+        )  # (jarrodnorwell) fixed KeyError: 'data', fixed // error
         params = params or {}
         params.update({"__a": 1, "__d": "dis"})
 

--- a/instagrapi/mixins/user.py
+++ b/instagrapi/mixins/user.py
@@ -386,7 +386,6 @@ class UserMixin:
         return self.search_users_v1(query, count)
 
     def search_followers_v1(self, user_id: str, query: str) -> List[UserShort]:
-
         """
         Search users by followers (Private Mobile API)
 
@@ -507,7 +506,7 @@ class UserMixin:
             if end_cursor:
                 variables["after"] = end_cursor
             data = self.public_graphql_request(
-                variables, query_hash="e7e2f4da4b02303f74f0841279e52d76"
+                variables, query_hash="58712303d941c6855d4e888c5f0cd22f"
             )
             if not data["user"] and not users:
                 raise UserNotFound(user_id=user_id, **data)
@@ -662,7 +661,7 @@ class UserMixin:
             if end_cursor:
                 variables["after"] = end_cursor
             data = self.public_graphql_request(
-                variables, query_hash="5aefa9893005572d237da5068082d8d5"
+                variables, query_hash="37479f2b8209594dde7facb0d904896a"
             )
             if not data["user"] and not users:
                 raise UserNotFound(user_id=user_id, **data)

--- a/instagrapi/types.py
+++ b/instagrapi/types.py
@@ -29,6 +29,10 @@ class Resource(BaseModel):
 
 
 class User(BaseModel):
+    model_config = ConfigDict(
+        coerce_numbers_to_str=True
+    )  # (jarrodnorwell) fixed city_id issue
+
     pk: str
     username: str
     full_name: str


### PR DESCRIPTION
**[public.py#L208-L210](https://github.com/jarrodnorwell/instagrapi/blob/c49daa5ae597cddf5f3fade3bc5e1419c6353d1e/instagrapi/mixins/public.py#L208-L210)** has been modified to replace any unwanted `.com//.*` strings with `.com/.*`

**[user.py#L509](https://github.com/jarrodnorwell/instagrapi/blob/c49daa5ae597cddf5f3fade3bc5e1419c6353d1e/instagrapi/mixins/user.py#L509)** has been modified to use an up-to-date `query_hash` for `user_following_gql_chunk`

**[user.py#L664](https://github.com/jarrodnorwell/instagrapi/blob/c49daa5ae597cddf5f3fade3bc5e1419c6353d1e/instagrapi/mixins/user.py#L664)** has been modified to use an up-to-date `query_hash` for `user_followers_gql_chunk`

Fixes #1648, #1638, #1580, #1060, #864
Possible fix for #1050