### PR TITLE
When downloading the story file, the request.get request was used dir…

### DIFF
--- a/instagrapi/extractors.py
+++ b/instagrapi/extractors.py
@@ -372,6 +372,7 @@ def extract_hashtag_v1(data):
 def extract_story_v1(data):
     """Extract story from Private API"""
     story = deepcopy(data)
+    story["pk"] = str(story.get("pk"))
     if "video_versions" in story:
         # Select Best Quality by Resolutiuon
         story["video_url"] = sorted(
@@ -437,7 +438,7 @@ def extract_story_gql(data):
     if story_cta_url:
         story["links"] = [StoryLink(**{"webUri": story_cta_url})]
     story["user"] = extract_user_short(story.get("owner"))
-    story["pk"] = int(story["id"])
+    story["pk"] = str(story["id"])
     story["id"] = f"{story['id']}_{story['owner']['id']}"
     story["code"] = InstagramIdCodec.encode(story["pk"])
     story["taken_at"] = story["taken_at_timestamp"]

--- a/instagrapi/mixins/public.py
+++ b/instagrapi/mixins/public.py
@@ -123,7 +123,7 @@ class PublicRequestMixin:
                 continue
 
     def _send_public_request(
-        self, url, data=None, params=None, headers=None, return_json=False
+        self, url, data=None, params=None, headers=None, return_json=False, stream=None, timeout=None
     ):
         self.public_requests_count += 1
         if headers:
@@ -135,12 +135,15 @@ class PublicRequestMixin:
         try:
             if data is not None:  # POST
                 response = self.public.data(
-                    url, data=data, params=params, proxies=self.public.proxies
+                    url, data=data, params=params, proxies=self.public.proxies, timeout=timeout
                 )
             else:  # GET
                 response = self.public.get(
-                    url, params=params, proxies=self.public.proxies
+                    url, params=params, proxies=self.public.proxies, stream=stream, timeout=timeout
                 )
+
+            if stream:
+                return response
 
             expected_length = int(response.headers.get("Content-Length") or 0)
             actual_length = response.raw.tell()

--- a/instagrapi/mixins/story.py
+++ b/instagrapi/mixins/story.py
@@ -42,10 +42,6 @@ class StoryMixin:
         parts = [p for p in path.split("/") if p and p.isdigit()]
         return str(parts[0])
 
-    # def story_info_gql(self, story_pk: str):
-    #     # GQL havent video_url :-(
-    #     return self.media_info_gql(self, str(story_pk))
-
     def story_info_v1(self, story_pk: str) -> Story:
         """
         Get Story by pk or id
@@ -62,8 +58,7 @@ class StoryMixin:
         """
         story_id = self.media_id(story_pk)
         story_pk, user_id = story_id.split("_")
-        # result = self.private_request(f"media/{story_pk}/info/")
-        # story = extract_story_v1(result["items"][0])
+
         stories = self.user_stories_v1(user_id)
         for story in stories:
             self._stories_cache[story.pk] = story
@@ -253,23 +248,22 @@ class StoryMixin:
         )
 
     def story_download(
-        self, story_pk: int, filename: str = "", folder: Path = ""
+        self, story_pk: str, filename: str = "", folder: Path = ""
     ) -> Path:
         """
         Download story media by media_type
 
         Parameters
         ----------
-        story_pk: int
+        story_pk: str
 
         Returns
         -------
         Path
             Path for the file downloaded
         """
-        story_pk = int(story_pk)
         story = self.story_info(story_pk)
-        url = story.thumbnail_url if story.media_type == 1 else story.video_url
+        url = str(story.thumbnail_url if story.media_type == 1 else story.video_url)
         return self.story_download_by_url(url, filename, folder)
 
     def story_download_by_url(
@@ -300,8 +294,10 @@ class StoryMixin:
         )
         filename = "%s.%s" % (filename, fname.rsplit(".", 1)[1]) if filename else fname
         path = Path(folder) / filename
-        response = requests.get(url, stream=True, timeout=self.request_timeout)
+
+        response = self._send_public_request(url, stream=True, timeout=self.request_timeout)
         response.raise_for_status()
+
         with open(path, "wb") as f:
             response.raw.decode_content = True
             shutil.copyfileobj(response.raw, f)


### PR DESCRIPTION
…ectly, which did not include the data specified by the user at the beginning of the work: headers, proxy & other data. Because of this, users from countries where Instagram is blocked could not use the method correctly.

There was some confusion in the story_pk typing.
Critical error due to video_url: HttpUrl and thumbnail_url: HttpUrl being passed directly to the urllib.parse.urlparse method, which does not support it.