### PR TITLE
Fix timestamp type string format convert to datetime format

### DIFF
--- a/instagrapi/extractors.py
+++ b/instagrapi/extractors.py
@@ -2,6 +2,7 @@ import html
 import json
 import re
 from copy import deepcopy
+from datetime import datetime
 
 from .types import (
     Account,
@@ -320,6 +321,10 @@ def extract_direct_message(data):
     if "voice_media" in data:
         if "media" in data["voice_media"]:
             data["media"] = extract_direct_media(data["voice_media"]["media"])
+    if 'timestamp' in data:
+        if type(data['timestamp']) is not datetime:
+            timestamp_int = int(data['timestamp']) / 1000000
+            data['timestamp'] = datetime.fromtimestamp(timestamp_int)
     clip = data.get("clip", {})
     if clip:
         if "clip" in clip:


### PR DESCRIPTION
When calling the direct_send function, 'timestamp' returns the data string like '1703950333486186' instead of datetime format, so we added a code that converts the string in timestamp format to datetime format.