### PR TITLE
Update album.py

### DIFF
--- a/instagrapi/mixins/album.py
+++ b/instagrapi/mixins/album.py
@@ -153,7 +153,7 @@ class UploadAlbumMixin:
         children = []
         for path in paths:
             path = Path(path)
-            if path.suffix.lower() in (".jpg", ".jpeg"):
+            if path.suffix.lower() in (".jpg", ".jpeg", ".webp"):
                 upload_id, width, height = self.photo_rupload(path, to_album=True)
                 children.append(
                     {


### PR DESCRIPTION
Downloading images from an album post may have an original file format of webp and can cause an AlbumUnknownFormat exception when attempting to upload an album with it included. 

Including "webp" fixes this. 

Tested on this album post: 
https://www.instagram.com/p/C1u-lMpOFbx/ 

It includes a webp image.

Download folder content after cl.album_download:

['nationhood_3273829132873110682.mp4.jpg', 'nationhood_3273829058499604913.mp4', 'nationhood_3273829132873110682.mp4', 'nationhood_3273829058499604913.mp4.jpg', 'nationhood_3273829210753019095.webp']

I've also encountered ".heic" image file formats when attempting to download image posts, I haven't included it in the commit.