### PR TITLE
Update types.py

### DIFF
--- a/instagrapi/types.py
+++ b/instagrapi/types.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from pydantic import (
     BaseModel,
@@ -122,7 +122,7 @@ class Location(TypesBaseModel):
 
 
 class Media(TypesBaseModel):
-    pk: str | int
+    pk: Union[str, int]
     id: str
     code: str
     taken_at: datetime


### PR DESCRIPTION
I'm using python 3.9 and found that there was an error in types.py with the old union operator and after changing it to Union[str, int] i was able to import without errors. the readme says >=3.9 compatible but idk sorry if this is stupid