### PR TITLE
Fix reply message timestamp and user_id extraction

### DIFF
--- a/instagrapi/extractors.py
+++ b/instagrapi/extractors.py
@@ -307,6 +307,10 @@ def extract_reply_message(data):
             # Instagram ¯\_(ツ)_/¯
             clip = clip.get("clip")
         data["clip"] = extract_media_v1(clip)
+
+    data['timestamp'] = datetime.datetime.fromtimestamp(data['timestamp'] // 1_000_000)
+    data['user_id'] = str(data['user_id'])
+
     return ReplyMessage(**data)
 
 


### PR DESCRIPTION
These changes fix this error:
<img width="939" alt="image" src="https://github.com/subzeroid/instagrapi/assets/13950666/6b40e27b-769b-45e8-9ac4-70ea2fe64cbe">

The error was caused by the timestamp not being converted into the correct unit, like what happens in `extract_direct_message`. I also added a line that coerces the `user_id` into a string, which is also done in `extract_direct_message`.
