### PR TITLE
Collection Mixin: fix last_media_pk comparison

### DIFF
--- a/instagrapi/mixins/collection.py
+++ b/instagrapi/mixins/collection.py
@@ -155,7 +155,7 @@ class CollectionMixin:
                 collection_pk, max_id=next_max_id
             )
             for item in items:
-                if last_media_pk and last_media_pk == item["media"]["pk"]:
+                if last_media_pk and last_media_pk == item.pk:
                     found_last_media_pk = True
                     break
                 total_items.append(item)


### PR DESCRIPTION
`items` is a list of `Media`, which are thus non subscriptable.

This PR fixes the access error by accessing directly to the `pk` property of Media.

---
<details>
<summary>Error for reference</summary>

```
    liked_posts = self.insta_client.liked_medias(
  File "/usr/local/lib/python3.10/site-packages/instagrapi/mixins/collection.py", line 94, in liked_medias
    return self.collection_medias("liked", amount, last_media_pk)
  File "/usr/local/lib/python3.10/site-packages/instagrapi/mixins/collection.py", line 188, in collection_medias
    return self.collection_medias_v1(
  File "/usr/local/lib/python3.10/site-packages/instagrapi/mixins/collection.py", line 158, in collection_medias_v1
    if last_media_pk and last_media_pk == item["media"]["pk"]:
TypeError: 'Media' object is not subscriptable
```

</details>