### PR TITLE
Enable hashing by .pk to convert lists into sets

### DIFF
--- a/instagrapi/types.py
+++ b/instagrapi/types.py
@@ -31,6 +31,8 @@ class Resource(TypesBaseModel):
 
 
 class User(TypesBaseModel):
+    def __hash__(self):
+        return hash(self.pk)
     pk: str
     username: str
     full_name: str
@@ -68,6 +70,8 @@ class User(TypesBaseModel):
 
 
 class Account(TypesBaseModel):
+    def __hash__(self):
+        return hash(self.pk)
     pk: str
     username: str
     full_name: str
@@ -86,6 +90,8 @@ class Account(TypesBaseModel):
 
 
 class UserShort(TypesBaseModel):
+    def __hash__(self):
+        return hash(self.pk)
     pk: str
     username: Optional[str] = None
     full_name: Optional[str] = ""

--- a/instagrapi/types.py
+++ b/instagrapi/types.py
@@ -31,8 +31,6 @@ class Resource(TypesBaseModel):
 
 
 class User(TypesBaseModel):
-    def __hash__(self):
-        return hash(self.pk)
     pk: str
     username: str
     full_name: str
@@ -70,8 +68,6 @@ class User(TypesBaseModel):
 
 
 class Account(TypesBaseModel):
-    def __hash__(self):
-        return hash(self.pk)
     pk: str
     username: str
     full_name: str
@@ -92,6 +88,10 @@ class Account(TypesBaseModel):
 class UserShort(TypesBaseModel):
     def __hash__(self):
         return hash(self.pk)
+    def __eq__(self, other):
+        if isinstance(other, UserShort):
+            return self.pk == other.pk
+        return NotImplemented
     pk: str
     username: Optional[str] = None
     full_name: Optional[str] = ""


### PR DESCRIPTION
Sometimes, the retrieved userlist when using chunks, contains repeated followers. This can be fixed by converting the resulting list into a set, then the repeated users would be automatically removed. A set can only contain userShort objects if it can generate a hash out of them. This is why two new functions were added to the class UserShort. (hash and eq)
```
class UserShort(TypesBaseModel):
    def __hash__(self):
        return hash(self.pk)
    def __eq__(self, other):
        if isinstance(other, UserShort):
            return self.pk == other.pk
        return NotImplemented
    pk: str
    username: Optional[str] = None
    full_name: Optional[str] = ""
    profile_pic_url: Optional[HttpUrl] = None
    profile_pic_url_hd: Optional[HttpUrl] = None
    is_private: Optional[bool] = None
    # is_verified: bool  # not found in hashtag_medias_v1
    # stories: List = [] # not found in fbsearch_suggested_profiles
```