### PR TITLE
Add PIL to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ PySocks==1.7.1
 pydantic==2.6.4
 moviepy==1.0.3
 pycryptodomex==3.20.0
+PIL~=8.1.1


### PR DESCRIPTION
Hello, I've tried to use instagrapi from scratch and after `pip install instagrapi ` I receive this error:
<img width="1107" alt="image" src="https://github.com/subzeroid/instagrapi/assets/41271764/614a3ba2-9fe1-418d-b79d-e95c0c72b242">
Should we add PIL to requirements.txt?