### PR TITLE
Adjust validation error for Story', 'is_paid_partnership'

### DIFF
--- a/instagrapi/types.py
+++ b/instagrapi/types.py
@@ -323,7 +323,7 @@ class Story(TypesBaseModel):
     video_url: Optional[HttpUrl] = None  # for Video and IGTV
     video_duration: Optional[float] = 0.0  # for Video and IGTV
     sponsor_tags: List[UserShort]
-    is_paid_partnership: Optional[bool]
+    is_paid_partnership: Optional[bool] = False
     mentions: List[StoryMention]
     links: List[StoryLink]
     hashtags: List[StoryHashtag]


### PR DESCRIPTION
When trying to use the `photo_upload_to_story` function it caused the exception below:

`validation error for Story', 'is_paid_partnership', "  Field required [type=missing, input_value={'links': [StoryLink(webU...], 'clips_metadata': {}}, input_type=dict]", '    For further information visit https://errors.pydantic.dev/2.6/v/missing',`

I identified that the Story type had the is_paid_partnership argument as optional, but without a default value.
