### PR TITLE
add broadcast channel

### DIFF
--- a/instagrapi/extractors.py
+++ b/instagrapi/extractors.py
@@ -29,6 +29,7 @@ from .types import (
     StoryMedia,
     StoryMention,
     Track,
+    Broadcast,
     User,
     UserShort,
     Usertag,
@@ -196,8 +197,15 @@ def extract_user_short(data):
     return UserShort(**data)
 
 
+def extract_broadcast_channel(data):
+    """ Extract broadcast channel infos """
+    channels = data["pinned_channels_info"]["pinned_channels_list"]
+    return [Broadcast(**channel) for channel in channels]
+
+
 def extract_user_gql(data):
     """For Public GraphQL API"""
+    data["broadcast_channel"] = extract_broadcast_channel(data)
     return User(
         pk=data["id"],
         media_count=data["edge_owner_to_timeline_media"]["count"],
@@ -212,6 +220,7 @@ def extract_user_gql(data):
 
 def extract_user_v1(data):
     """For Private API"""
+    data["broadcast_channel"] = extract_broadcast_channel(data)
     data["external_url"] = data.get("external_url") or None
     versions = data.get("hd_profile_pic_versions")
     pic_hd = versions[-1] if versions else data.get("hd_profile_pic_url_info", {})

--- a/instagrapi/types.py
+++ b/instagrapi/types.py
@@ -40,6 +40,20 @@ class BioLink(TypesBaseModel):
     open_external_url_with_in_app_browser: Optional[bool] = None
 
 
+class Broadcast(TypesBaseModel):
+    title: str
+    thread_igid: str
+    subtitle: str
+    invite_link: str
+    is_member: bool
+    group_image_uri: str
+    group_image_background_uri: str
+    thread_subtype: int
+    number_of_members: int
+    creator_igid: str | None
+    creator_username: str
+
+
 class User(TypesBaseModel):
     pk: str
     username: str
@@ -56,6 +70,8 @@ class User(TypesBaseModel):
     external_url: Optional[str] = None
     account_type: Optional[int] = None
     is_business: bool
+
+    broadcast_channel: List[Broadcast] = []
 
     public_email: Optional[str] = None
     contact_phone_number: Optional[str] = None


### PR DESCRIPTION
Two files was change:

**1. extractors.py:** New extractor ('extract_broadcast_channel') for broadcast data exctration.

**2. types.py:** Create a 'Broadcast' class,  And add to 'User' class an list of 'BroadCast'.

Since a broadcast is similar to a direct, you don’t need any extra methods. 

But since not all direct features work in a broadcast (like sending a message, for example), it might be a good idea to create something like a 'BroadcastMixin' to make sure only the features available for broadcasts are used.
