### PR TITLE
fix(LoginMixin): update username and password attributes on subsequent `login` calls

### DIFF
--- a/instagrapi/mixins/auth.py
+++ b/instagrapi/mixins/auth.py
@@ -398,12 +398,12 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
             A boolean value
         """
 
-        if not self.username or not self.password:
-            if username is None or password is None:
-                raise BadCredentials("Both username and password must be provided.")
-
+        if username and password:
             self.username = username
             self.password = password
+        
+        if self.username is None or self.password is None:
+            raise BadCredentials("Both username and password must be provided.")
 
         if relogin:
             self.authorization_data = {}


### PR DESCRIPTION
After the first call to `cl.login`, once `self.username` and `self.password` are set to other than `None`, subsequent calls ignore `username` and `password` arguments:

```python
from instagrapi import Client

cl = Client()
cl.login('incorrectUser', 'incorrectPassword')  # Throws BadPassword error
print(f"{cl.username}:{cl.password}")           # Prints: incorrectUser:incorrectPassword
cl.login('correctUser', 'correctPassword')      # Should login correctly but throws BadPassword error
print(f"{cl.username}:{cl.password}")           # Still prints: incorrectUser:incorrectPassword
```

So, if you try to login with incorrect data, you have to restart or set `cl.username` and `cl.password` manually to login correctly:

```python
from instagrapi import Client

cl = Client()
cl.login('incorrectUser', 'incorrectPassword')  # Throws BadPassword error
print(f"{cl.username}:{cl.password}")           # Prints: incorrectUser:incorrectPassword

cl.username = 'correctUser'
cl.password = 'correctPassword'

cl.login()                                      # Returns True
# or
cl.login('correctUser', 'correctPassword')      # Returns True
```

This change updates the `username` and `password` attributes if both arguments of the function are valid. It keeps the old ones if they are `None` or empty strings.