### PR TITLE
"fix: status 201: public request ...."

### DIFF
--- a/instagrapi/mixins/user.py
+++ b/instagrapi/mixins/user.py
@@ -141,7 +141,7 @@ class UserMixin:
             An object of User type
         """
         username = str(username).lower()
-        return extract_user_gql(self.public_a1_request(f"/{username!s}/")["user"])
+        return extract_user_gql(self.private_request(f"users/web_profile_info/?username={username!s}")["data"]["user"])
 
     def user_info_by_username_v1(self, username: str) -> User:
         """


### PR DESCRIPTION
fix: #1957

Only one file was changed:

**1. user.py:** change the `public_a1_request` to  `private_request`

Instagram uses `/api/v1/users/web_profile_info/?username={username}` to grab user info, and that’s managed by `private_request` in `instagrapi`.

It only fetches basic info like user_id, username, follower count, and number of posts.