### PR TITLE
Fix return type conversion in InstagramIdCodec.decode method

### DIFF
--- a/instagrapi/mixins/media.py
+++ b/instagrapi/mixins/media.py
@@ -123,7 +123,7 @@ class MediaMixin:
         B-fKL9qpeab -> 2278584739065882267
         CCQQsCXjOaBfS3I2PpqsNkxElV9DXj61vzo5xs0 -> 2346448800803776129
         """
-        return InstagramIdCodec.decode(code[:11])
+        return str(InstagramIdCodec.decode(code[:11]))
 
     def media_pk_from_url(self, url: str) -> str:
         """


### PR DESCRIPTION
The code change ensures the return value is converted to a string before being returned.
<img width="741" alt="Snipaste_2024-10-26_14-12-04" src="https://github.com/user-attachments/assets/90cb2fff-22bd-4733-b120-5e331a91b94f">
