### PR TITLE
Add compatibility for newer moviepy versions (>=1.0.3)

### DIFF
--- a/instagrapi/mixins/clip.py
+++ b/instagrapi/mixins/clip.py
@@ -239,8 +239,13 @@ class UploadClipMixin:
             highlight_start_time = 0
         try:
             import moviepy.editor as mp
+            from moviepy.editor import CompositeVideoClip, ImageClip, TextClip, VideoFileClip
         except ImportError:
-            raise Exception("Please install moviepy>=1.0.3 and retry")
+            try:
+                import moviepy as mp
+                from moviepy import CompositeVideoClip, ImageClip, TextClip, VideoFileClip
+            except ImportError:
+                raise Exception("Please install moviepy>=1.0.3 and retry")
         # get all media to create the reel
         video = mp.VideoFileClip(str(path))
         audio_clip = mp.AudioFileClip(str(tmpaudio))
@@ -388,7 +393,10 @@ def analyze_video(path: Path, thumbnail: Path = None) -> tuple:
     try:
         import moviepy.editor as mp
     except ImportError:
-        raise Exception("Please install moviepy>=1.0.3 and retry")
+        try:
+            import moviepy as mp
+        except ImportError:
+            raise Exception("Please install moviepy>=1.0.3 and retry")
 
     print(f'Analyzing CLIP file "{path}"')
     video = mp.VideoFileClip(str(path))

--- a/instagrapi/mixins/clip.py
+++ b/instagrapi/mixins/clip.py
@@ -239,11 +239,9 @@ class UploadClipMixin:
             highlight_start_time = 0
         try:
             import moviepy.editor as mp
-            from moviepy.editor import CompositeVideoClip, ImageClip, TextClip, VideoFileClip
         except ImportError:
             try:
                 import moviepy as mp
-                from moviepy import CompositeVideoClip, ImageClip, TextClip, VideoFileClip
             except ImportError:
                 raise Exception("Please install moviepy>=1.0.3 and retry")
         # get all media to create the reel

--- a/instagrapi/mixins/igtv.py
+++ b/instagrapi/mixins/igtv.py
@@ -295,7 +295,10 @@ def analyze_video(path: Path, thumbnail: Path = None) -> tuple:
     try:
         import moviepy.editor as mp
     except ImportError:
-        raise Exception("Please install moviepy>=1.0.3 and retry")
+        try:
+            import moviepy as mp
+        except ImportError:
+            raise Exception("Please install moviepy>=1.0.3 and retry")
 
     print(f'Analyzing IGTV file "{path}"')
     with contextlib.ExitStack() as stack:

--- a/instagrapi/mixins/video.py
+++ b/instagrapi/mixins/video.py
@@ -894,7 +894,10 @@ def analyze_video(path: Path, thumbnail: Path = None) -> tuple:
     try:
         import moviepy.editor as mp
     except ImportError:
-        raise Exception("Please install moviepy>=1.0.3 and retry")
+        try:
+            import moviepy as mp
+        except ImportError:
+            raise Exception("Please install moviepy>=1.0.3 and retry")
 
     print(f'Analyzing video file "{path}"')
     video = mp.VideoFileClip(str(path))

--- a/instagrapi/story.py
+++ b/instagrapi/story.py
@@ -6,9 +6,12 @@ from urllib.parse import urlparse
 from .types import StoryBuild, StoryMention, StorySticker
 
 try:
-    from moviepy.editor import CompositeVideoClip, ImageClip, TextClip, VideoFileClip
+    from moviepy import CompositeVideoClip, ImageClip, TextClip, VideoFileClip
 except ImportError:
-    raise Exception("Please install moviepy==1.0.3 and retry")
+    try:
+        from moviepy.editor import CompositeVideoClip, ImageClip, TextClip, VideoFileClip
+    except ImportError:
+        raise Exception("Please install moviepy>=1.0.3 and retry")
 
 try:
     from PIL import Image

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ requirements = [
 
 setup(
     name="instagrapi",
-    version="2.1.3",
+    version="2.1.4",
     author="Mark Subzeroid",
     author_email="143403577+subzeroid@users.noreply.github.com",
     license="MIT",


### PR DESCRIPTION
Newer versions of moviepy structure the imports differently (e.g., import moviepy as mp instead of import moviepy.editor as mp). This update modifies the import logic to additionally support newer moviepy versions, improving compatibility across environments.