### PR TITLE
fix/core-issues

### DIFF
--- a/instagrapi/mixins/clip.py
+++ b/instagrapi/mixins/clip.py
@@ -285,7 +285,7 @@ class UploadClipMixin:
             "audio_cluster_id": track.audio_cluster_id,
             "audio_asset_start_time_in_ms": highlight_start_time,
             "derived_content_start_time_in_ms": 0,
-            "overlap_duration_in_ms": 15000,
+            "overlap_duration_in_ms": int(video.duration * 1000),
             "product": "story_camera_clips_v2",
             "song_name": track.title,
             "artist_name": track.display_artist,

--- a/instagrapi/mixins/private.py
+++ b/instagrapi/mixins/private.py
@@ -388,7 +388,16 @@ class PrivateRequestMixin:
                 raise ClientForbiddenError(e, response=e.response, **last_json)
             elif e.response.status_code == 400:
                 error_type = last_json.get("error_type")
-                if message == "challenge_required":
+                if last_json.get("two_factor_info"):
+                    if not last_json.get("message"):
+                        last_json["message"] = "Two-factor authentication required"
+                    if last_json.get("error_type") != "two_factor_required":
+                        self.logger.info(
+                            f"Changing error_type from {last_json.get('error_type')} to two_factor_required due to presence of two_factor_info"
+                        )
+                        last_json["error_type"] = "two_factor_required"
+                    raise TwoFactorRequired(**last_json)
+                elif message == "challenge_required":
                     raise ChallengeRequired(**last_json)
                 elif message == "feedback_required":
                     raise FeedbackRequired(


### PR DESCRIPTION
I've fixed two critical bugs related to auth and reel uploads.

1.  Auth: I ensured `TwoFactorRequired` is raised for 2FA challenges.
    - I modified `instagrapi/mixins/private.py` within the `_send_private_request` method's HTTP 400 error handling.
    - If the JSON response from a failed login attempt contains `two_factor_info`, the `TwoFactorRequired` exception is now reliably raised.
    - This addresses GitHub Issue #2195, ensuring that the two-factor authentication flow can be correctly initiated by client applications.

2.  Upload: I made `overlap_duration_in_ms` dynamic for reels with music.
    - I modified `instagrapi/mixins/clip.py` in the `clip_upload_as_reel_with_music` method.
    - The `overlap_duration_in_ms` parameter within `music_params` is now dynamically calculated as `int(video.duration * 1000)` based on the actual video duration.
    - This replaces a previously hardcoded value (15000ms) and aims to resolve 500 server errors reported in GitHub Issue #2190 by providing more accurate metadata for reels uploaded with accompanying music.

These changes address key issues to improve the library's stability for authentication and media uploading. I've also presented and discussed a development plan with you for further feature enhancements.