### PR TITLE
Fix broken "Contributing guide" link

### DIFF
--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -5,7 +5,7 @@ and how to work with the code base.
 
 Before you dive into this, it is best to read:
 
-* The [Contributing guide](development-guide.md)
+* The [Contributing guide](../CONTRIBUTING.md.md)
 
 ## Docker
 


### PR DESCRIPTION
The "Contributing guide" link in `development-guide.md` was pointing to itself. Updated the link to reference the actual `CONTRIBUTING.md` file.
```diff
- * The [Contributing guide](development-guide.md)
+ * The [Contributing guide](../CONTRIBUTING.md.md)
```