### PR TITLE
Fix #2297 - Unable to download instagram videos, due to ClipsMetadata`s mashup_info variable missing.

### DIFF
--- a/instagrapi/types.py
+++ b/instagrapi/types.py
@@ -373,7 +373,7 @@ class ClipsMetadata(TypesBaseModel):
     external_media_info: Optional[dict] = None
     is_fan_club_promo_video: bool = False
     is_shared_to_fb: bool = False
-    mashup_info: ClipsMashupInfo
+    mashup_info: Optional[ClipsMashupInfo] = None
     merchandising_pill_info: Optional[dict] = None
     music_canonical_id: str
     music_info: Optional[dict] = None


### PR DESCRIPTION
Fix #2297 - [BUG] Unable to download instagram videos, due to ClipsMetadata`s mashup_info variable missing.