### PR TITLE
fix: migrate Direct photos to attachment flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,4 @@ dmypy.json
 ig_settings.json
 .backlog/
 .playwright-mcp/
+docs/superpowers/

--- a/docs/usage-guide/direct.md
+++ b/docs/usage-guide/direct.md
@@ -36,7 +36,7 @@
 | direct_thread_unmute(thread_id: int)                                      | bool                    | Unmute the thread
 | direct_thread_mute_video_call(thread_id: int, revert: bool = False)       | bool                    | Mute video call for the thread
 | direct_thread_unmute_video_call(thread_id: int)                           | bool                    | Unmute video call for the thread
-| direct_send_photo(path: Path, user_ids: List[int], thread_ids: List[int]) | DirectMessage           | Send a direct photo to list of users or threads
+| direct_send_photo(path: Path, user_ids: List[int], thread_ids: List[int]) | DirectMessage           | Send a direct photo to users in an existing thread or directly to thread ids
 | direct_send_video(path: Path, user_ids: List[int], thread_ids: List[int]) | DirectMessage           | Send a direct video (.mp4 / H.264 + AAC) to list of users or threads
 | direct_send_voice(path: Path, user_ids: List[int], thread_ids: List[int], waveform: Optional[List[float]]) | DirectMessage | Send a direct voice (audio) message; path must be m4a/AAC
 | video_upload_to_direct(path: Path, caption: str, thumbnail: Path, mentions: List[StoryMention], thread_ids: List[int] = [], extra_data: Dict[str, str] = {}) | DirectMessage | Upload video to direct thread as a story and configure it
@@ -53,6 +53,7 @@ Notes:
 
 * For `direct_send()`, `direct_media_share()`, `direct_send_photo()`, `direct_send_video()`, and `direct_send_voice()`, pass exactly one of `user_ids` or `thread_ids`.
 * Direct recipient arguments accept either one id (`user_ids=123`) or a list of ids (`user_ids=[123]`).
+* Direct photo, video, and voice attachments sent with `user_ids` require an existing Direct thread. Use `direct_send()` to start the conversation first, or prefer `thread_ids` when the thread id is already known.
 * Direct message requests / invitations are exposed as `direct_requests()`; `direct_pending_inbox()` remains as the older name.
 * `direct_pending_requests_preview()` is the lightweight Android-app preview for request counters; use `direct_requests()` when you need the actual threads.
 * `direct_channels()` and `direct_search_gen_ai_bots()` expose raw app surfaces whose response shape may vary by rollout.

--- a/instagrapi/mixins/direct.py
+++ b/instagrapi/mixins/direct.py
@@ -19,6 +19,7 @@ from instagrapi.extractors import (
     extract_direct_thread,
     extract_user_short,
 )
+from instagrapi.image_util import prepare_image
 from instagrapi.types import (
     DirectMessage,
     DirectShortThread,
@@ -722,23 +723,73 @@ class DirectMixin:
 
     def direct_send_photo(self, path: Path, user_ids: List[int] = [], thread_ids: List[int] = []) -> DirectMessage:
         """
-        Send a direct photo to list of users or threads
+        Send a direct photo to a list of users or threads.
+
+        Instagram retired ``direct_v2/threads/broadcast/configure_photo/``.
+        Direct photos now use the messenger image attachment flow:
+
+        1. Normalize the image to JPEG and upload it to
+           ``rupload.facebook.com/messenger_image/``.
+        2. Send the returned ``media_id`` through
+           ``direct_v2/threads/broadcast/photo_attachment/``.
+
+        When ``user_ids`` is used, an existing Direct thread is required.
 
         Parameters
         ----------
         path: Path
-            Path to photo that will be posted on the thread
+            Path to a JPG, JPEG, PNG, or WebP image.
         user_ids: List[int]
-            List of unique identifier of Users id
+            List of unique identifiers of Users id.
         thread_ids: List[int]
-            List of unique identifier of Direct Message thread id
+            List of unique identifiers of Direct Message thread id.
 
         Returns
         -------
         DirectMessage
-            An object of DirectMessage
+            An object of DirectMessage.
         """
-        return self.direct_send_file(path, user_ids, thread_ids, content_type="photo")
+        assert self.user_id, "Login required"
+        user_ids = _direct_id_list(user_ids)
+        thread_ids = _direct_id_list(thread_ids)
+        assert (user_ids or thread_ids) and not (user_ids and thread_ids), (
+            "Specify user_ids or thread_ids, but not both"
+        )
+        if user_ids:
+            thread_ids = [self._direct_thread_id_from_user_ids(user_ids, "photo")]
+
+        path = Path(path)
+        valid_extensions = {".jpg", ".jpeg", ".png", ".webp"}
+        if path.suffix.lower() not in valid_extensions:
+            raise ValueError("Invalid file format. Only JPG/JPEG/PNG/WEBP files are supported.")
+        photo_bytes, _ = prepare_image(str(path), max_side=1080)
+
+        entity_name = f"fb_uploader_{int(time.time() * 1000)}"
+        media_id = self._photo_rupload(photo_bytes, entity_name)
+
+        token = self.generate_mutation_token()
+        data = {
+            "action": "send_item",
+            "is_x_transport_forward": "false",
+            "is_shh_mode": "0",
+            "thread_ids": dumps([int(tid) for tid in thread_ids]),
+            "send_attribution": "inbox",
+            "client_context": token,
+            "attachment_fbid": str(media_id),
+            "device_id": self.android_device_id,
+            "mutation_token": token,
+            "_uuid": self.uuid,
+            "allow_full_aspect_ratio": "true",
+            "btt_dual_send": "false",
+            "is_ae_dual_send": "false",
+            "offline_threading_id": token,
+        }
+        result = self.private_request(
+            "direct_v2/threads/broadcast/photo_attachment/",
+            data=self.with_default_data(data),
+            with_signature=False,
+        )
+        return extract_direct_message(result["payload"])
 
     def _direct_video_metadata(self, path: Path) -> Tuple[int, int, float]:
         width, height, duration_sec = 720, 1280, 1.0
@@ -928,6 +979,36 @@ class DirectMixin:
         if extra_headers:
             headers.update(extra_headers)
         return headers
+
+    def _photo_rupload(self, photo_bytes: bytes, entity_name: str) -> int:
+        """Upload JPEG bytes to messenger_image and return its media_id."""
+        import requests
+
+        url = f"https://rupload.facebook.com/messenger_image/{entity_name}"
+
+        sess = requests.Session()
+        sess.verify = self.tls_verify
+        if getattr(self, "proxy", None):
+            sess.proxies = {"http": self.proxy, "https": self.proxy}
+
+        headers = self._messenger_rupload_headers({"image_type": "FILE_ATTACHMENT"})
+        headers.update(
+            {
+                "content-type": "application/octet-stream",
+                "offset": "0",
+                "x-entity-length": str(len(photo_bytes)),
+                "x-entity-name": entity_name,
+                "x-entity-type": "image/jpeg",
+            }
+        )
+        response = sess.post(url, data=photo_bytes, headers=headers, timeout=120)
+        if response.status_code != 200:
+            raise ClientError(f"messenger_image upload POST failed: {response.status_code} {response.text[:300]}")
+        try:
+            media_id = int(response.json()["media_id"])
+        except Exception as exc:
+            raise ClientError(f"messenger_image response missing media_id: {response.text[:300]}") from exc
+        return media_id
 
     def _video_rupload(self, video_bytes: bytes, entity_name: str, waterfall_id: str) -> int:
         """Upload mp4 bytes to ``rupload.facebook.com/messenger_video/...`` and
@@ -1162,53 +1243,11 @@ class DirectMixin:
         assert (user_ids or thread_ids) and not (user_ids and thread_ids), (
             "Specify user_ids or thread_ids, but not both"
         )
-        method = f"configure_{content_type}"
-        token = self.generate_mutation_token()
-        nav_chains = [
-            (
-                "6xQ:direct_media_picker_photos_fragment:1,5rG:direct_thread:2,"
-                "5ME:direct_quick_camera_fragment:3,5ME:direct_quick_camera_fragment:4,"
-                "4ju:reel_composer_preview:5,5rG:direct_thread:6,5rG:direct_thread:7,"
-                "6xQ:direct_media_picker_photos_fragment:8,5rG:direct_thread:9"
-            ),
-            (
-                "1qT:feed_timeline:1,7Az:direct_inbox:2,7Az:direct_inbox:3,"
-                "5rG:direct_thread:4,6xQ:direct_media_picker_photos_fragment:5,"
-                "5rG:direct_thread:6,5rG:direct_thread:7,"
-                "6xQ:direct_media_picker_photos_fragment:8,5rG:direct_thread:9"
-            ),
-        ]
-        kwargs = {}
-        data = {
-            "action": "send_item",
-            "is_shh_mode": "0",
-            "send_attribution": "direct_thread",
-            "client_context": token,
-            "mutation_token": token,
-            "nav_chain": random.choices(nav_chains),
-            "offline_threading_id": token,
-        }
-        if content_type == "video":
-            data["video_result"] = ""
-            kwargs["to_direct"] = True
         if content_type == "photo":
-            data["send_attribution"] = "inbox"
-            data["allow_full_aspect_ratio"] = "true"
-        if user_ids:
-            data["recipient_users"] = dumps([[int(uid) for uid in user_ids]])
-        if thread_ids:
-            data["thread_ids"] = dumps([int(tid) for tid in thread_ids])
-        path = Path(path)
-        upload_id = str(int(time.time() * 1000))
-        upload_id, width, height = getattr(self, f"{content_type}_rupload")(path, upload_id, **kwargs)[:3]
-        data["upload_id"] = upload_id
-        # data['content_type'] = content_type
-        result = self.private_request(
-            f"direct_v2/threads/broadcast/{method}/",
-            data=self.with_default_data(data),
-            with_signature=False,
-        )
-        return extract_direct_message(result["payload"])
+            return self.direct_send_photo(path, user_ids, thread_ids)
+        if content_type == "video":
+            return self.direct_send_video(path, user_ids, thread_ids)
+        raise ValueError('content_type must be "photo" or "video"')
 
     def direct_send_cutout_sticker(
         self,

--- a/tests/live/test_direct.py
+++ b/tests/live/test_direct.py
@@ -1,3 +1,5 @@
+from PIL import Image
+
 from instagrapi.exceptions import DirectMessageNotFound
 from tests import helpers as _helpers
 from tests.helpers import *
@@ -209,6 +211,13 @@ class ClientDirectMediaLiveTestCase(_helpers.ClientPrivateTestCase):
             ],
         )
 
+    def make_photo_png(self):
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".png") as tmp:
+            path = Path(tmp.name)
+        Image.new("RGBA", (64, 48), (37, 99, 235, 128)).save(path)
+        self.addCleanup(lambda: path.unlink(missing_ok=True))
+        return path
+
     def thread_id_by_participants(self, client, user_id):
         thread = client.direct_thread_by_participants([user_id])
         thread_id = thread.get("thread_v2_id") or thread.get("thread_id")
@@ -297,6 +306,55 @@ class ClientDirectMediaLiveTestCase(_helpers.ClientPrivateTestCase):
                 time.sleep(3)
             else:
                 self.fail(f"Direct reaction was still visible: {getattr(cleared_message, 'reactions', None)}")
+        finally:
+            if thread_id:
+                self.cleanup_direct_media_messages(thread_id, sent_messages, [sender, recipient])
+
+    def test_direct_send_photo_with_thread_and_user_ids(self):
+        sender = self.cl
+        recipient = self.fresh_accounts(1, exclude_user_ids={sender.user_id})[0]
+        photo_path = self.make_photo_png()
+        sent_messages = []
+        thread_id = None
+
+        try:
+            seed_message = sender.direct_send(
+                f"instagrapi direct photo live warm {int(time.time())}",
+                user_ids=[recipient.user_id],
+            )
+            self.assertIsInstance(seed_message, DirectMessage)
+            sent_messages.append((sender, seed_message))
+
+            thread_id = seed_message.thread_id or self.thread_id_by_participants(sender, recipient.user_id)
+            self.assertTrue(thread_id)
+
+            reply_message = recipient.direct_answer(
+                thread_id,
+                f"instagrapi direct photo live reply {int(time.time())}",
+            )
+            self.assertIsInstance(reply_message, DirectMessage)
+            sent_messages.append((recipient, reply_message))
+
+            thread_photo = sender.direct_send_photo(photo_path, thread_ids=[thread_id])
+            self.assertIsInstance(thread_photo, DirectMessage)
+            self.assertTrue(thread_photo.id)
+            sent_messages.append((sender, thread_photo))
+
+            user_photo = sender.direct_send_photo(photo_path, user_ids=[recipient.user_id])
+            self.assertIsInstance(user_photo, DirectMessage)
+            self.assertTrue(user_photo.id)
+            sent_messages.append((sender, user_photo))
+
+            for sent_photo in (thread_photo, user_photo):
+                received_photo = None
+                for _ in range(6):
+                    received_photo = self.direct_message_by_id(recipient, thread_id, sent_photo.id)
+                    if received_photo and received_photo.item_type == "media" and received_photo.media:
+                        break
+                    time.sleep(2)
+                self.assertIsNotNone(received_photo)
+                self.assertEqual(received_photo.item_type, "media")
+                self.assertIsNotNone(received_photo.media)
         finally:
             if thread_id:
                 self.cleanup_direct_media_messages(thread_id, sent_messages, [sender, recipient])

--- a/tests/regression/test_direct.py
+++ b/tests/regression/test_direct.py
@@ -1,3 +1,5 @@
+from PIL import Image
+
 from instagrapi.exceptions import DirectMessageNotFound
 from instagrapi.extractors import extract_direct_thread
 from tests.helpers import *
@@ -361,6 +363,13 @@ class DirectMixinRegressionTestCase(unittest.TestCase):
     def make_voice_file(self, content=b"voice-bytes"):
         return self.make_temp_file(".m4a", content)
 
+    def make_photo_file(self, suffix=".png"):
+        with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+            path = Path(tmp.name)
+        Image.new("RGBA", (8, 6), (37, 99, 235, 128)).save(path)
+        self.addCleanup(lambda: path.unlink(missing_ok=True))
+        return path
+
     def direct_payload(self):
         return {
             "payload": {
@@ -565,6 +574,153 @@ class DirectMixinRegressionTestCase(unittest.TestCase):
                 return FakeResponse({"media_id": media_id})
 
         return FakeSession()
+
+    def test_direct_send_photo_uploads_and_broadcasts_for_thread_ids(self):
+        client = self.build_client()
+        expected = Mock(spec=DirectMessage)
+        path = self.make_photo_file()
+
+        with (
+            mock.patch("instagrapi.mixins.direct.time.time", return_value=1234.567),
+            mock.patch.object(client, "_photo_rupload", return_value=987654321, create=True) as rupload,
+            mock.patch.object(client, "generate_mutation_token", return_value="mutation-token"),
+            mock.patch("instagrapi.mixins.direct.extract_direct_message", return_value=expected),
+            mock.patch.object(client, "private_request", return_value=self.direct_payload()) as private,
+        ):
+            result = client.direct_send_photo(path, thread_ids=[123])
+
+        self.assertIs(result, expected)
+        rupload.assert_called_once()
+        photo_bytes, entity_name = rupload.call_args.args
+        self.assertTrue(photo_bytes.startswith(b"\xff\xd8"))
+        self.assertEqual(entity_name, "fb_uploader_1234567")
+        private.assert_called_once_with(
+            "direct_v2/threads/broadcast/photo_attachment/",
+            data=mock.ANY,
+            with_signature=False,
+        )
+        data = private.call_args.kwargs["data"]
+        self.assertEqual(json.loads(data["thread_ids"]), [123])
+        self.assertEqual(data["attachment_fbid"], "987654321")
+        self.assertEqual(data["client_context"], "mutation-token")
+        self.assertEqual(data["mutation_token"], "mutation-token")
+        self.assertEqual(data["offline_threading_id"], "mutation-token")
+        self.assertEqual(data["allow_full_aspect_ratio"], "true")
+
+    def test_direct_send_photo_resolves_existing_thread_for_user_ids(self):
+        client = self.build_client()
+        expected = Mock(spec=DirectMessage)
+        path = self.make_photo_file()
+        thread_id = "340282366841710300949128149448121770626"
+
+        with (
+            mock.patch.object(
+                client,
+                "direct_thread_by_participants",
+                return_value={"thread_v2_id": thread_id},
+            ) as thread_lookup,
+            mock.patch.object(client, "_photo_rupload", return_value=123, create=True),
+            mock.patch.object(client, "generate_mutation_token", return_value="mutation-token"),
+            mock.patch("instagrapi.mixins.direct.extract_direct_message", return_value=expected),
+            mock.patch.object(client, "private_request", return_value=self.direct_payload()) as private,
+        ):
+            result = client.direct_send_photo(path, user_ids=[42])
+
+        self.assertIs(result, expected)
+        thread_lookup.assert_called_once_with([42])
+        data = private.call_args.kwargs["data"]
+        self.assertEqual(json.loads(data["thread_ids"]), [int(thread_id)])
+
+    def test_direct_send_photo_raises_before_upload_when_existing_thread_is_missing(self):
+        client = self.build_client()
+
+        with mock.patch.object(client, "direct_thread_by_participants", return_value={}) as thread_lookup:
+            with mock.patch.object(client, "_photo_rupload", create=True) as rupload:
+                with self.assertRaises(DirectThreadNotFound):
+                    client.direct_send_photo("missing.png", user_ids=[42])
+
+        thread_lookup.assert_called_once_with([42])
+        rupload.assert_not_called()
+
+    def test_direct_send_photo_rejects_unsupported_extension(self):
+        client = self.build_client()
+        path = self.make_temp_file(".gif", b"not-an-image")
+
+        with self.assertRaisesRegex(ValueError, "JPG/JPEG/PNG/WEBP"):
+            client.direct_send_photo(path, thread_ids=[123])
+
+    def test_direct_send_file_delegates_to_current_photo_and_video_flows(self):
+        client = self.build_client()
+        photo_result = Mock(spec=DirectMessage)
+        video_result = Mock(spec=DirectMessage)
+
+        with (
+            mock.patch.object(client, "direct_send_photo", return_value=photo_result) as send_photo,
+            mock.patch.object(client, "direct_send_video", return_value=video_result) as send_video,
+            mock.patch.object(client, "photo_rupload", return_value=("1", 1, 1)),
+            mock.patch.object(client, "video_rupload", return_value=("2", 1, 1)),
+            mock.patch.object(client, "private_request", return_value=self.direct_payload()),
+        ):
+            photo = client.direct_send_file("photo.jpg", thread_ids=[123], content_type="photo")
+            video = client.direct_send_file("video.mp4", user_ids=[42], content_type="video")
+
+        self.assertIs(photo, photo_result)
+        self.assertIs(video, video_result)
+        send_photo.assert_called_once_with("photo.jpg", [], [123])
+        send_video.assert_called_once_with("video.mp4", [42], [])
+
+    def test_photo_rupload_posts_jpeg_with_messenger_headers(self):
+        client = self.build_client()
+        client.proxy = "http://proxy.example:8080"
+        session = self.fake_rupload_session(media_id=987654321)
+
+        with (
+            mock.patch("requests.Session", return_value=session),
+            mock.patch.object(
+                client,
+                "_messenger_rupload_headers",
+                return_value={"authorization": "Bearer token", "image_type": "FILE_ATTACHMENT"},
+            ) as headers,
+        ):
+            media_id = client._photo_rupload(b"photo-bytes", "fb_uploader_123")
+
+        self.assertEqual(media_id, 987654321)
+        headers.assert_called_once_with({"image_type": "FILE_ATTACHMENT"})
+        self.assertEqual(session.verify, client.tls_verify)
+        self.assertEqual(session.proxies, {"http": client.proxy, "https": client.proxy})
+        self.assertEqual(len(session.calls), 1)
+        method, url, upload_headers, body = session.calls[0]
+        self.assertEqual(method, "POST")
+        self.assertEqual(url, "https://rupload.facebook.com/messenger_image/fb_uploader_123")
+        self.assertEqual(body, b"photo-bytes")
+        self.assertEqual(upload_headers["image_type"], "FILE_ATTACHMENT")
+        self.assertEqual(upload_headers["content-type"], "application/octet-stream")
+        self.assertEqual(upload_headers["offset"], "0")
+        self.assertEqual(upload_headers["x-entity-length"], "11")
+        self.assertEqual(upload_headers["x-entity-name"], "fb_uploader_123")
+        self.assertEqual(upload_headers["x-entity-type"], "image/jpeg")
+
+    def test_photo_rupload_raises_for_failed_upload(self):
+        client = self.build_client()
+        session = mock.Mock()
+        session.proxies = {}
+        session.post.return_value = mock.Mock(status_code=500, text="server error")
+
+        with mock.patch("requests.Session", return_value=session):
+            with self.assertRaisesRegex(ClientError, "messenger_image upload POST failed: 500"):
+                client._photo_rupload(b"photo-bytes", "fb_uploader_123")
+
+    def test_photo_rupload_raises_when_media_id_is_missing(self):
+        client = self.build_client()
+        session = mock.Mock()
+        session.proxies = {}
+        response = mock.Mock(status_code=200, text='{"status":"ok"}')
+        response.json.return_value = {"status": "ok"}
+        session.post.return_value = response
+
+        with mock.patch("requests.Session", return_value=session):
+            with self.assertRaisesRegex(ClientError, "messenger_image response missing media_id"):
+                client._photo_rupload(b"photo-bytes", "fb_uploader_123")
 
     def test_direct_send_video_uploads_and_broadcasts_for_thread_ids(self):
         client = self.build_client()

--- a/tests/regression/test_direct.py
+++ b/tests/regression/test_direct.py
@@ -366,7 +366,10 @@ class DirectMixinRegressionTestCase(unittest.TestCase):
     def make_photo_file(self, suffix=".png"):
         with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
             path = Path(tmp.name)
-        Image.new("RGBA", (8, 6), (37, 99, 235, 128)).save(path)
+        if suffix.lower() in {".jpg", ".jpeg"}:
+            Image.new("RGB", (8, 6), (37, 99, 235)).save(path)
+        else:
+            Image.new("RGBA", (8, 6), (37, 99, 235, 128)).save(path)
         self.addCleanup(lambda: path.unlink(missing_ok=True))
         return path
 
@@ -607,6 +610,44 @@ class DirectMixinRegressionTestCase(unittest.TestCase):
         self.assertEqual(data["offline_threading_id"], "mutation-token")
         self.assertEqual(data["allow_full_aspect_ratio"], "true")
 
+    def test_direct_send_photo_accepts_jpeg_and_webp_inputs(self):
+        client = self.build_client()
+
+        for suffix in (".jpeg", ".webp"):
+            with self.subTest(suffix=suffix):
+                path = self.make_photo_file(suffix)
+                with (
+                    mock.patch.object(client, "_photo_rupload", return_value=123) as rupload,
+                    mock.patch.object(client, "generate_mutation_token", return_value="token"),
+                    mock.patch(
+                        "instagrapi.mixins.direct.extract_direct_message",
+                        return_value=Mock(spec=DirectMessage),
+                    ),
+                    mock.patch.object(client, "private_request", return_value=self.direct_payload()),
+                ):
+                    client.direct_send_photo(path, thread_ids=[123])
+
+                photo_bytes, _ = rupload.call_args.args
+                self.assertTrue(photo_bytes.startswith(b"\xff\xd8"))
+
+    def test_direct_send_photo_requires_login(self):
+        client = Client()
+
+        with self.assertRaisesRegex(AssertionError, "Login required"):
+            client.direct_send_photo("missing.png", thread_ids=[123])
+
+    def test_direct_send_photo_requires_exactly_one_recipient_mode(self):
+        client = self.build_client()
+
+        for user_ids, thread_ids in (([], []), ([42], [123])):
+            with self.subTest(user_ids=user_ids, thread_ids=thread_ids):
+                with self.assertRaisesRegex(AssertionError, "Specify user_ids or thread_ids, but not both"):
+                    client.direct_send_photo(
+                        "missing.png",
+                        user_ids=user_ids,
+                        thread_ids=thread_ids,
+                    )
+
     def test_direct_send_photo_resolves_existing_thread_for_user_ids(self):
         client = self.build_client()
         expected = Mock(spec=DirectMessage)
@@ -668,6 +709,12 @@ class DirectMixinRegressionTestCase(unittest.TestCase):
         self.assertIs(video, video_result)
         send_photo.assert_called_once_with("photo.jpg", [], [123])
         send_video.assert_called_once_with("video.mp4", [42], [])
+
+    def test_direct_send_file_rejects_unsupported_content_type(self):
+        client = self.build_client()
+
+        with self.assertRaisesRegex(ValueError, 'content_type must be "photo" or "video"'):
+            client.direct_send_file("voice.m4a", thread_ids=[123], content_type="audio")
 
     def test_photo_rupload_posts_jpeg_with_messenger_headers(self):
         client = self.build_client()


### PR DESCRIPTION
## Summary

- replace the retired Direct photo configure route with the current `messenger_image` upload and `photo_attachment` broadcast flow
- preserve the `direct_send_photo` and `direct_send_file` APIs, normalize supported image inputs to JPEG, and resolve `user_ids` through an existing thread like video and voice sends
- document the existing-thread requirement and add regression plus live recipient-delivery coverage

Thanks @KhawerAbbas7 for the detailed reproduction.

Fixes #2757

## Root cause

Instagram now returns HTTP 500 from the legacy Direct photo configure endpoint. The current client flow uploads the image as a file attachment and broadcasts the returned media ID through `photo_attachment`.

## Verification

- `pytest -q tests/regression` — 700 passed, 3 skipped, 29 subtests passed
- `pytest -q tests/regression/test_direct.py` — 54 passed, 4 subtests passed
- Ruff, pre-commit, strict MkDocs build, and `git diff --check` passed; Bandit reported no medium/high findings
- fresh-clone live test with two test accounts passed for both `thread_ids` and existing-thread `user_ids`; the recipient read each item as `media`
- the exact report scenario passed: download an Instagram profile picture with `photo_download_by_url`, then deliver it with `direct_send_photo`
