### PR TITLE
fix: restore direct CAA login preparation

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -97,6 +97,7 @@ jobs:
             tests/regression/test_comments.py::CommentRepliesRegressionTestCase \
             tests/regression/test_current_app_profile.py::CurrentAppProfileRegressionTestCase \
             tests/regression/test_auth_story.py::AuthAndStoryRegressionTestCase \
+            tests/regression/test_attestation.py::CaaLoginRegressionTestCase \
             tests/regression/test_download.py::DownloadRegressionTestCase \
             tests/regression/test_notes.py::NoteMixinRegressionTestCase \
             tests/regression/test_location.py::LocationMixinRegressionTestCase \

--- a/docs/usage-guide/totp.md
+++ b/docs/usage-guide/totp.md
@@ -85,7 +85,7 @@ cl.bloks_two_step_verification_enter_backup_code(context)
 result = cl.bloks_two_step_verification_verify_code(context, "12345678", challenge="backup_codes")
 ```
 
-`bloks_caa_login(...)` runs the complete current CAA sequence. For low-level inspection, call `bloks_caa_login_prepare(...)` before `bloks_caa_login_send_request(...)`; the send helper requires the account access context returned by Instagram during that preflight. `bloks_extract_two_step_verification_context(...)` extracts a legacy Bloks two-factor context when the login response exposes one.
+`bloks_caa_login(...)` runs the complete current CAA sequence. For low-level inspection, `bloks_caa_login_send_request(...)` now runs `bloks_caa_login_prepare(...)` automatically when the client has no server-issued account access context; existing prepared context is reused on later calls. Its domain, waterfall ID, offline experiment group, and Bloks versioning ID overrides are forwarded to that automatic preflight. Pass `auto_prepare=False` to require pre-existing state, or call the preparation helper explicitly when you need to inspect or control the preflight separately. `bloks_extract_two_step_verification_context(...)` extracts a legacy Bloks two-factor context when the login response exposes one.
 
 `bloks_extract_login_response(...)` returns decoded `login_response`, response `headers`, cookie values, raw cookie header text, and the raw embedded object when Instagram returns a successful Bloks login payload. It returns `{}` when the response is an intermediate UI state or an error. `bloks_apply_login_response(...)` can then copy the returned authorization data and cookies into the current client session.
 

--- a/instagrapi/mixins/bloks.py
+++ b/instagrapi/mixins/bloks.py
@@ -604,16 +604,34 @@ class BloksMixin:
             login=True,
         )
 
-    def bloks_caa_login_prepare(self, username: str = "", domain: Optional[str] = None) -> bool:
+    def bloks_caa_login_prepare(
+        self,
+        username: str = "",
+        domain: Optional[str] = None,
+        waterfall_id: str = "",
+        offline_experiment_group: str = "caa_iteration_v3_perf_ig_4",
+        bloks_versioning_id: str = "",
+    ) -> bool:
         """Run the ordered device and CAA preflight needed before login."""
         if not self.usdid_registered and not self.usdid_register():
             return False
-        self.bloks_caa_login_process_client_data(domain=domain)
+        self.bloks_caa_login_process_client_data(
+            waterfall_id=waterfall_id,
+            offline_experiment_group=offline_experiment_group,
+            bloks_versioning_id=bloks_versioning_id,
+            domain=domain,
+        )
         self.attestation_challenge_nonce = ""
         self.attestation_key_nonce = ""
         self.attestation_create_android_keystore(domain=domain)
         if self.caa_aac:
-            self.bloks_caa_login_oauth_token_fetch(username=username, domain=domain)
+            self.bloks_caa_login_oauth_token_fetch(
+                username=username,
+                waterfall_id=waterfall_id,
+                offline_experiment_group=offline_experiment_group,
+                bloks_versioning_id=bloks_versioning_id,
+                domain=domain,
+            )
         return bool(self.caa_aac and self.attestation_challenge_nonce)
 
     def bloks_caa_login_send_request(
@@ -626,13 +644,14 @@ class BloksMixin:
         offline_experiment_group: str = "caa_iteration_v3_perf_ig_4",
         bloks_versioning_id: str = "",
         domain: Optional[str] = None,
+        auto_prepare: bool = True,
     ) -> Dict:
         """
         Send the current CAA/Bloks login request used before Bloks 2FA.
 
-        This low-level helper requires the server-issued account access context
-        and uses the attestation state populated by
-        :meth:`bloks_caa_login_prepare`.
+        When needed, this low-level helper obtains the server-issued account
+        access context through :meth:`bloks_caa_login_prepare` before encrypting
+        the password. Set ``auto_prepare=False`` to require pre-existing state.
 
         Returns
         -------
@@ -640,13 +659,36 @@ class BloksMixin:
             Raw Instagram response.
         """
         contact_point = username or self.username
-        encrypted_password = password if password.startswith("#PWD_") else self.password_encrypt(password)
-        flow_id = waterfall_id or self.caa_waterfall_id or str(uuid4())
-        self.caa_waterfall_id = flow_id
+        if auto_prepare and not self.caa_aac:
+            preflight_state = (
+                self.caa_aac,
+                self.caa_waterfall_id,
+                self.attestation_challenge_nonce,
+                self.attestation_key_nonce,
+            )
+            try:
+                self.bloks_caa_login_prepare(
+                    username=contact_point,
+                    domain=domain,
+                    waterfall_id=waterfall_id,
+                    offline_experiment_group=offline_experiment_group,
+                    bloks_versioning_id=bloks_versioning_id,
+                )
+            except Exception:
+                (
+                    self.caa_aac,
+                    self.caa_waterfall_id,
+                    self.attestation_challenge_nonce,
+                    self.attestation_key_nonce,
+                ) = preflight_state
+                raise
         if not self.caa_aac:
             raise ClientError(
                 "CAA login requires a server-issued aac; call bloks_caa_login_prepare() before send_login_request"
             )
+        encrypted_password = password if password.startswith("#PWD_") else self.password_encrypt(password)
+        flow_id = waterfall_id or self.caa_waterfall_id or str(uuid4())
+        self.caa_waterfall_id = flow_id
         # Recent CAA login screens emit short base36-like input ids. Hex-only
         # UUID prefixes are accepted by the VM but can return a null-payload 404.
         text_input_id = f"{uuid4().hex[:4]}ig"
@@ -762,7 +804,12 @@ class BloksMixin:
                 "two_step": {},
                 "reason": "CAA preflight did not return account access and attestation data",
             }
-        result = self.bloks_caa_login_send_request(password, username=username, domain=domain)
+        result = self.bloks_caa_login_send_request(
+            password,
+            username=username,
+            domain=domain,
+            auto_prepare=prepare,
+        )
         logged_in = self.bloks_apply_login_response(result)
         two_step = {}
         if not logged_in and self.bloks_caa_login_needs_two_step(result):

--- a/tests/regression/test_attestation.py
+++ b/tests/regression/test_attestation.py
@@ -1,5 +1,6 @@
 import base64
 import json
+from inspect import signature
 
 from Cryptodome.Hash import SHA256
 from Cryptodome.PublicKey import ECC
@@ -237,6 +238,28 @@ class CaaLoginRegressionTestCase(unittest.TestCase):
             }
         }
 
+    def test_caa_login_public_signatures_preserve_positional_prefixes(self):
+        client = self.build_client()
+
+        prepare_params = list(signature(client.bloks_caa_login_prepare).parameters)
+        send_params = list(signature(client.bloks_caa_login_send_request).parameters)
+
+        self.assertEqual(prepare_params[:2], ["username", "domain"])
+        self.assertEqual(
+            send_params,
+            [
+                "password",
+                "username",
+                "login_attempt_count",
+                "try_num",
+                "waterfall_id",
+                "offline_experiment_group",
+                "bloks_versioning_id",
+                "domain",
+                "auto_prepare",
+            ],
+        )
+
     def test_process_client_data_extracts_server_issued_aac(self):
         client = self.build_client()
         aac = '{"aac_init_timestamp":1,"aacjid":"j","aaccs":"server"}'
@@ -359,14 +382,41 @@ class CaaLoginRegressionTestCase(unittest.TestCase):
 
         with (
             mock.patch.object(client, "usdid_register", side_effect=register),
-            mock.patch.object(client, "bloks_caa_login_process_client_data", side_effect=process),
+            mock.patch.object(
+                client,
+                "bloks_caa_login_process_client_data",
+                side_effect=process,
+            ) as process_client_data,
             mock.patch.object(client, "attestation_create_android_keystore", side_effect=attest),
-            mock.patch.object(client, "bloks_caa_login_oauth_token_fetch", side_effect=oauth),
+            mock.patch.object(
+                client,
+                "bloks_caa_login_oauth_token_fetch",
+                side_effect=oauth,
+            ) as oauth_token_fetch,
         ):
-            result = client.bloks_caa_login_prepare(domain="b.i.instagram.com")
+            result = client.bloks_caa_login_prepare(
+                username="override_user",
+                domain="b.i.instagram.com",
+                waterfall_id="waterfall-1",
+                offline_experiment_group="experiment-1",
+                bloks_versioning_id="bloks-version-1",
+            )
 
         self.assertTrue(result)
         self.assertEqual(order, ["register", "process", "attestation", "oauth"])
+        process_client_data.assert_called_once_with(
+            waterfall_id="waterfall-1",
+            offline_experiment_group="experiment-1",
+            bloks_versioning_id="bloks-version-1",
+            domain="b.i.instagram.com",
+        )
+        oauth_token_fetch.assert_called_once_with(
+            username="override_user",
+            waterfall_id="waterfall-1",
+            offline_experiment_group="experiment-1",
+            bloks_versioning_id="bloks-version-1",
+            domain="b.i.instagram.com",
+        )
 
     def test_prepare_stops_when_usdid_registration_is_rejected(self):
         client = self.build_client()
@@ -424,16 +474,164 @@ class CaaLoginRegressionTestCase(unittest.TestCase):
             result = client.bloks_caa_login_prepare(username="override_user")
 
         self.assertFalse(result)
-        oauth.assert_called_once_with(username="override_user", domain=None)
+        oauth.assert_called_once_with(
+            username="override_user",
+            waterfall_id="",
+            offline_experiment_group="caa_iteration_v3_perf_ig_4",
+            bloks_versioning_id="",
+            domain=None,
+        )
 
-    def test_send_login_requires_server_issued_aac(self):
+    def test_send_login_auto_prepares_before_password_and_flow_selection(self):
+        client = self.build_client()
+        order = []
+
+        def prepare(**kwargs):
+            order.append("prepare")
+            client.caa_aac = "server-aac"
+            client.caa_waterfall_id = "prepared-waterfall"
+            return True
+
+        def encrypt(password):
+            order.append("encrypt")
+            return "#PWD_INSTAGRAM:4:1:encrypted"
+
+        def action(*args, **kwargs):
+            order.append("action")
+            return {"status": "ok"}
+
+        client.password_encrypt = Mock(side_effect=encrypt)
+
+        with (
+            mock.patch.object(client, "bloks_caa_login_prepare", side_effect=prepare) as login_prepare,
+            mock.patch.object(client, "bloks_async_action", side_effect=action) as async_action,
+        ):
+            result = client.bloks_caa_login_send_request(
+                "dummy_password",
+                domain="b.i.instagram.com",
+                offline_experiment_group="experiment-1",
+                bloks_versioning_id="bloks-version-1",
+            )
+
+        self.assertEqual(result, {"status": "ok"})
+        self.assertEqual(order, ["prepare", "encrypt", "action"])
+        login_prepare.assert_called_once_with(
+            username="example_user",
+            domain="b.i.instagram.com",
+            waterfall_id="",
+            offline_experiment_group="experiment-1",
+            bloks_versioning_id="bloks-version-1",
+        )
+        params = async_action.call_args.args[1]
+        self.assertEqual(params["server_params"]["waterfall_id"], "prepared-waterfall")
+
+    def test_send_login_uses_aac_even_when_prepare_returns_false(self):
         client = self.build_client()
 
-        with mock.patch.object(client, "bloks_async_action") as action, self.assertRaises(ClientError) as cm:
-            client.bloks_caa_login_send_request("dummy_password")
+        def prepare(**kwargs):
+            client.caa_aac = "server-aac"
+            return False
+
+        client.password_encrypt = Mock(return_value="#PWD_INSTAGRAM:4:1:encrypted")
+
+        with (
+            mock.patch.object(client, "bloks_caa_login_prepare", side_effect=prepare),
+            mock.patch.object(client, "bloks_async_action", return_value={"status": "ok"}) as action,
+        ):
+            result = client.bloks_caa_login_send_request("dummy_password")
+
+        self.assertEqual(result, {"status": "ok"})
+        action.assert_called_once()
+
+    def test_send_login_requires_aac_after_auto_prepare(self):
+        client = self.build_client()
+        client.password_encrypt = Mock(return_value="#PWD_INSTAGRAM:4:1:encrypted")
+
+        with (
+            mock.patch.object(client, "bloks_caa_login_prepare", return_value=True) as prepare,
+            mock.patch.object(client, "bloks_async_action") as action,
+            self.assertRaises(ClientError) as cm,
+        ):
+            client.bloks_caa_login_send_request(
+                "dummy_password",
+                username="override_user",
+                waterfall_id="waterfall-1",
+            )
 
         self.assertIn("server-issued aac", str(cm.exception))
+        prepare.assert_called_once_with(
+            username="override_user",
+            domain=None,
+            waterfall_id="waterfall-1",
+            offline_experiment_group="caa_iteration_v3_perf_ig_4",
+            bloks_versioning_id="",
+        )
+        client.password_encrypt.assert_not_called()
         action.assert_not_called()
+
+    def test_send_login_propagates_prepare_exceptions_before_password_encryption(self):
+        client = self.build_client()
+        error = RuntimeError("preflight failed")
+        client.password_encrypt = Mock(return_value="#PWD_INSTAGRAM:4:1:encrypted")
+
+        def prepare(**kwargs):
+            client.caa_aac = "partial-aac"
+            client.caa_waterfall_id = "partial-waterfall"
+            client.attestation_challenge_nonce = "partial-challenge"
+            client.attestation_key_nonce = "partial-key"
+            raise error
+
+        with (
+            mock.patch.object(client, "bloks_caa_login_prepare", side_effect=prepare) as login_prepare,
+            mock.patch.object(client, "bloks_async_action") as action,
+        ):
+            for _ in range(2):
+                with self.assertRaises(RuntimeError) as cm:
+                    client.bloks_caa_login_send_request("dummy_password")
+
+                self.assertIs(cm.exception, error)
+                self.assertEqual(client.caa_aac, "")
+                self.assertEqual(client.caa_waterfall_id, "")
+                self.assertEqual(client.attestation_challenge_nonce, "")
+                self.assertEqual(client.attestation_key_nonce, "")
+
+        self.assertEqual(login_prepare.call_count, 2)
+        client.password_encrypt.assert_not_called()
+        action.assert_not_called()
+
+    def test_send_login_can_disable_auto_prepare(self):
+        client = self.build_client()
+        client.password_encrypt = Mock(return_value="#PWD_INSTAGRAM:4:1:encrypted")
+
+        with (
+            mock.patch.object(client, "bloks_caa_login_prepare") as prepare,
+            mock.patch.object(client, "bloks_async_action") as action,
+            self.assertRaises(ClientError),
+        ):
+            client.bloks_caa_login_send_request("dummy_password", auto_prepare=False)
+
+        prepare.assert_not_called()
+        client.password_encrypt.assert_not_called()
+        action.assert_not_called()
+
+    def test_send_login_prepares_only_once_across_repeated_calls(self):
+        client = self.build_client()
+
+        def prepare(**kwargs):
+            client.caa_aac = "server-aac"
+            return True
+
+        client.password_encrypt = Mock(return_value="#PWD_INSTAGRAM:4:1:encrypted")
+
+        with (
+            mock.patch.object(client, "bloks_caa_login_prepare", side_effect=prepare) as login_prepare,
+            mock.patch.object(client, "bloks_async_action", return_value={"status": "ok"}) as action,
+        ):
+            client.bloks_caa_login_send_request("dummy_password")
+            client.bloks_caa_login_send_request("dummy_password")
+
+        login_prepare.assert_called_once()
+        self.assertEqual(action.call_count, 2)
 
     def test_send_login_uses_server_aac_and_attestation_only_on_final_request(self):
         client = self.build_client()
@@ -441,7 +639,10 @@ class CaaLoginRegressionTestCase(unittest.TestCase):
         client.attestation_challenge_nonce = "challenge"
         client.password_encrypt = Mock(return_value="#PWD_INSTAGRAM:4:1:encrypted")
 
-        with mock.patch.object(client, "bloks_async_action", return_value={"status": "ok"}) as action:
+        with (
+            mock.patch.object(client, "bloks_caa_login_prepare") as prepare,
+            mock.patch.object(client, "bloks_async_action", return_value={"status": "ok"}) as action,
+        ):
             client.bloks_caa_login_send_request("dummy_password", domain="b.i.instagram.com")
 
         called_action, params = action.call_args.args[:2]
@@ -452,6 +653,7 @@ class CaaLoginRegressionTestCase(unittest.TestCase):
         self.assertEqual(params["server_params"]["waterfall_id"], client.caa_waterfall_id)
         self.assertEqual(action.call_args.kwargs["domain"], "b.i.instagram.com")
         self.assertTrue(action.call_args.kwargs["login"])
+        prepare.assert_not_called()
         attest = json.loads(action.call_args.kwargs["extra_headers"]["X-IG-Attest-Params"])
         self.assertEqual(attest["attestation"][0]["challenge_nonce"], "challenge")
 
@@ -525,6 +727,7 @@ class CaaLoginRegressionTestCase(unittest.TestCase):
             client.password,
             username=client.username,
             domain="b.i.instagram.com",
+            auto_prepare=False,
         )
 
     def test_full_caa_login_dispatches_profile_code_challenge(self):


### PR DESCRIPTION
## Summary
- Automatically run the CAA preflight when the public direct send helper has no server-issued AAC, while preserving prepared and explicit opt-out flows.
- Forward domain and flow overrides through process/OAuth preparation, and roll partial login state back when preparation raises so retries cannot skip an incomplete preflight.
- Document the compatibility behavior and add the CAA regression class to the Python 3.10-3.14 compatibility matrix.

## Verification
- `pytest -q -p no:cacheprovider tests/regression` — 762 passed, 3 skipped, 29 subtests passed
- `ruff check .`
- `ruff format --check .`
- `bandit -c pyproject.toml -r instagrapi`
- `mkdocs build --strict`
- `pre-commit run --all-files`
- `uv build`
- Live credential verification — the direct helper automatically completed the CAA preflight and returned a usable session; domain, waterfall, AAC, and attestation continuity were verified across the flow, with exactly one final credential request. The returned session was not applied or saved.

Related: subzeroid/aiograpi#428
