### PR TITLE
fix: require TLS 1.2 for realtime transport

### DIFF
--- a/instagrapi/realtime/mqttot.py
+++ b/instagrapi/realtime/mqttot.py
@@ -240,7 +240,13 @@ class SocketMQTToTTransport:
         self.host = host
         self.port = port
         self.timeout = timeout
-        self.tls_context = tls_context or ssl.create_default_context()
+        if tls_context is None:
+            tls_context = ssl.create_default_context()
+            default_minimum_version = tls_context.minimum_version
+            tls_context.minimum_version = ssl.TLSVersion.TLSv1_2
+            if default_minimum_version > tls_context.minimum_version:
+                tls_context.minimum_version = default_minimum_version
+        self.tls_context = tls_context
         self.proxy = proxy
         self.sock = None
 

--- a/tests/regression/test_realtime.py
+++ b/tests/regression/test_realtime.py
@@ -1,5 +1,6 @@
 import json
 import socket
+import ssl
 import threading
 import zlib
 from unittest import mock
@@ -117,6 +118,46 @@ def test_realtime_client_default_transport_uses_client_proxy():
 
     assert isinstance(realtime.transport, SocketMQTToTTransport)
     assert realtime.transport.proxy == "socks5://127.0.0.1:8888"
+
+
+def test_transport_default_context_requires_tls_1_2():
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    context.minimum_version = ssl.TLSVersion.MINIMUM_SUPPORTED
+
+    with mock.patch(
+        "instagrapi.realtime.mqttot.ssl.create_default_context",
+        return_value=context,
+    ):
+        transport = SocketMQTToTTransport("example.com")
+
+    assert transport.tls_context is context
+    assert context.minimum_version == ssl.TLSVersion.TLSv1_2
+
+
+def test_transport_default_context_preserves_stricter_tls_minimum():
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    context.minimum_version = ssl.TLSVersion.TLSv1_3
+
+    with mock.patch(
+        "instagrapi.realtime.mqttot.ssl.create_default_context",
+        return_value=context,
+    ):
+        transport = SocketMQTToTTransport("example.com")
+
+    assert transport.tls_context is context
+    assert context.minimum_version == ssl.TLSVersion.TLSv1_3
+
+
+def test_transport_does_not_modify_caller_supplied_weak_tls_context():
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    context.minimum_version = ssl.TLSVersion.MINIMUM_SUPPORTED
+
+    with mock.patch("instagrapi.realtime.mqttot.ssl.create_default_context") as create_context:
+        transport = SocketMQTToTTransport("example.com", tls_context=context)
+
+    assert transport.tls_context is context
+    assert context.minimum_version == ssl.TLSVersion.MINIMUM_SUPPORTED
+    create_context.assert_not_called()
 
 
 def test_transport_disconnect_shuts_down_socket_to_unblock_active_recv():


### PR DESCRIPTION
## Summary

- require TLS 1.2 or newer for library-created Realtime MQTT SSL contexts
- preserve stricter platform defaults and caller-provided SSL context policies
- add regression coverage for weak defaults, TLS 1.3 defaults, and custom contexts

## Security

Addresses [code scanning alert #18](https://github.com/subzeroid/instagrapi/security/code-scanning/18). The PR CodeQL run is the authoritative merge gate.

## Verification

- `765 passed, 3 skipped, 29 subtests passed` in the full regression suite
- `25 passed` in the focused Realtime regression suite
- Ruff check and format passed
- Bandit reported no issues
- strict MkDocs build passed
- all pre-commit hooks passed
- live TLS handshake to the Realtime endpoint negotiated TLS 1.3
