### PR TITLE
fix: map final retry responses to typed errors

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -106,7 +106,8 @@ jobs:
             tests/regression/test_timeline.py::TimelineRegressionTestCase \
             tests/regression/test_story_configure.py::StoryConfigureRegressionTestCase \
             tests/regression/test_video_metadata.py::VideoMetadataRegressionTestCase \
-            tests/regression/test_upload.py::UploadRegressionTestCase
+            tests/regression/test_upload.py::UploadRegressionTestCase \
+            tests/regression/test_retry.py::RetryRegressionTestCase
 
   build-docs:
     runs-on: ubuntu-latest

--- a/docs/usage-guide/interactions.md
+++ b/docs/usage-guide/interactions.md
@@ -190,6 +190,8 @@ cl.set_retry_config(
 )
 ```
 
+For the default Requests transport, `session_retry_total` controls adapter-level attempts for `session_retry_statuses`. After those attempts are exhausted, instagrapi receives the final response and raises its normal typed exception, such as `ClientThrottledError` for HTTP 429. When adapter retries are enabled, `public_request()` does not start a second retry package for the same configured status; when `session_retry_total<=0`, the existing `public_request_retries_count` loop remains active. Connection, TLS, DNS, and timeout exhaustion remain transport errors because there is no final HTTP response to map. The optional curl public transport uses its own adapter and is unaffected by these urllib3 settings.
+
 For public web endpoints that are sensitive to browser TLS fingerprints, install the optional curl transport:
 
 ```bash

--- a/instagrapi/mixins/private.py
+++ b/instagrapi/mixins/private.py
@@ -174,6 +174,7 @@ class PrivateRequestMixin:
                 status_forcelist=self.session_retry_statuses,
                 allowed_methods=["GET", "POST"],
                 backoff_factor=self.session_retry_backoff_factor,
+                raise_on_status=False,
             )
         except TypeError:
             return Retry(
@@ -181,6 +182,7 @@ class PrivateRequestMixin:
                 status_forcelist=self.session_retry_statuses,
                 method_whitelist=["GET", "POST"],
                 backoff_factor=self.session_retry_backoff_factor,
+                raise_on_status=False,
             )
 
     def _configure_private_session_retry(self):

--- a/instagrapi/mixins/public.py
+++ b/instagrapi/mixins/public.py
@@ -148,6 +148,7 @@ class PublicRequestMixin:
                 status_forcelist=self.session_retry_statuses,
                 allowed_methods=["GET", "POST"],
                 backoff_factor=self.session_retry_backoff_factor,
+                raise_on_status=False,
             )
         except TypeError:
             return Retry(
@@ -155,6 +156,7 @@ class PublicRequestMixin:
                 status_forcelist=self.session_retry_statuses,
                 method_whitelist=["GET", "POST"],
                 backoff_factor=self.session_retry_backoff_factor,
+                raise_on_status=False,
             )
 
     def _configure_public_session_retry(self):
@@ -238,6 +240,13 @@ class PublicRequestMixin:
             # except JSONDecodeError as e:
             #     raise ClientJSONDecodeError(e, respones=self.last_public_response)
             except ClientError as e:
+                response_status = getattr(getattr(e, "response", None), "status_code", None)
+                if (
+                    self.public_transport == "requests"
+                    and self.session_retry_total > 0
+                    and response_status in self.session_retry_statuses
+                ):
+                    raise
                 msg = str(e)
                 if all(
                     (
@@ -296,16 +305,14 @@ class PublicRequestMixin:
                     timeout=timeout,
                 )
 
-            if stream:
-                return response
-
-            expected_length = int(response.headers.get("Content-Length") or 0)
-            actual_length = response.raw.tell()
-            if actual_length < expected_length:
-                raise ClientIncompleteReadError(
-                    "Incomplete read ({} bytes read, {} more expected)".format(actual_length, expected_length),
-                    response=response,
-                )
+            if not stream:
+                expected_length = int(response.headers.get("Content-Length") or 0)
+                actual_length = response.raw.tell()
+                if actual_length < expected_length:
+                    raise ClientIncompleteReadError(
+                        "Incomplete read ({} bytes read, {} more expected)".format(actual_length, expected_length),
+                        response=response,
+                    )
 
             self.public_request_logger.debug("public_request %s: %s", response.status_code, response.url)
 
@@ -318,6 +325,8 @@ class PublicRequestMixin:
             )
             self.last_public_response = response
             response.raise_for_status()
+            if stream:
+                return response
             if return_json:
                 self.last_public_json = response.json()
                 return self.last_public_json
@@ -338,6 +347,8 @@ class PublicRequestMixin:
                 response=response,
             )
         except requests.HTTPError as e:
+            if stream:
+                e.response.close()
             if e.response.status_code == 401:
                 # HTTPError: 401 Client Error: Unauthorized for url: https://i.instagram.com/api/v1/users....
                 raise ClientUnauthorizedError(e, response=e.response)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -101,6 +101,21 @@ COMMENT_REPLIES_LIVE_FIXTURES = [
 ]
 
 
+def is_retryable_http_status_error(exc, statuses, endpoint=None):
+    statuses = set(statuses)
+    response = getattr(exc, "response", None)
+    status_code = getattr(response, "status_code", None) or getattr(exc, "code", None)
+    response_url = str(getattr(response, "url", "") or "")
+    if status_code in statuses:
+        return endpoint is None or endpoint in response_url
+    if not isinstance(exc, RetryError):
+        return False
+    if endpoint is None:
+        return True
+    message = str(exc)
+    return endpoint in message and any(f"{status} error responses" in message for status in statuses)
+
+
 class FreshAccountLoginTimeout(RuntimeError):
     pass
 

--- a/tests/live/test_media.py
+++ b/tests/live/test_media.py
@@ -128,8 +128,8 @@ class ClientMediaExtendTestCase(_helpers.ClientPrivateTestCase):
         try:
             try:
                 media = self.cl.igtv_upload(path, "Test title", "Test caption for IGTV")
-            except RetryError as exc:
-                if "configure_to_igtv" in str(exc) and "500 error responses" in str(exc):
+            except (ClientError, RetryError) as exc:
+                if is_retryable_http_status_error(exc, {500}, endpoint="configure_to_igtv"):
                     self.skipTest("Instagram returned server 500 for configure_to_igtv")
                 raise
             self.assertIsInstance(media, Media)
@@ -271,14 +271,12 @@ class ClientLinkedReelLiveTestCase(_helpers.ClientPrivateTestCase):
             try:
                 self.run_media_link_reel(client, origin_path, target_path, origin_cover, target_cover)
                 return
-            except (
-                ClipNotUpload,
-                PhotoNotUpload,
-                LoginRequired,
-                PleaseWaitFewMinutes,
-                ClientThrottledError,
-                RetryError,
-            ) as exc:
+            except (ClientError, RetryError) as exc:
+                if not isinstance(
+                    exc,
+                    (ClipNotUpload, PhotoNotUpload, LoginRequired, PleaseWaitFewMinutes, ClientThrottledError),
+                ) and not is_retryable_http_status_error(exc, client.session_retry_statuses):
+                    raise
                 upload_failures[exc.__class__.__name__] = upload_failures.get(exc.__class__.__name__, 0) + 1
                 continue
 

--- a/tests/live/test_upload.py
+++ b/tests/live/test_upload.py
@@ -253,11 +253,13 @@ class ClienUploadTestCase(_ClipMusicMetadataAssertionsMixin, _helpers.ClientPriv
             return payload
         self.fail(f"Scheduled media {media.id} was not accessible through media/infos: {last_result}")
 
+    def is_scheduled_publish_unavailable(self, exc):
+        return isinstance(exc, (ClientNotFoundError, ClientThrottledError, PleaseWaitFewMinutes)) or (
+            is_retryable_http_status_error(exc, self.cl.session_retry_statuses)
+        )
+
     def skip_unavailable_scheduled_publish(self, exc):
-        if exc is None or isinstance(
-            exc,
-            (ClientNotFoundError, ClientThrottledError, PleaseWaitFewMinutes, RetryError),
-        ):
+        if exc is None or self.is_scheduled_publish_unavailable(exc):
             self.skipTest("No usable scheduled publishing account was available")
         raise exc
 
@@ -276,7 +278,9 @@ class ClienUploadTestCase(_ClipMusicMetadataAssertionsMixin, _helpers.ClientPriv
             self.ensure_creator_account()
             try:
                 return upload()
-            except (ClientNotFoundError, ClientThrottledError, PleaseWaitFewMinutes, RetryError) as exc:
+            except (ClientError, RetryError) as exc:
+                if not self.is_scheduled_publish_unavailable(exc):
+                    raise
                 last_exc = exc
                 continue
         self.skip_unavailable_scheduled_publish(last_exc)
@@ -475,8 +479,8 @@ class ClienUploadTestCase(_ClipMusicMetadataAssertionsMixin, _helpers.ClientPriv
             caption_text = "Test caption for IGTV"
             try:
                 media = self.cl.igtv_upload(path, title, caption_text)
-            except RetryError as exc:
-                if "configure_to_igtv" in str(exc) and "500 error responses" in str(exc):
+            except (ClientError, RetryError) as exc:
+                if is_retryable_http_status_error(exc, {500}, endpoint="configure_to_igtv"):
                     self.skipTest("Instagram returned server 500 for configure_to_igtv")
                 raise
             self.assertIsInstance(media, Media)

--- a/tests/regression/test_retry.py
+++ b/tests/regression/test_retry.py
@@ -1,0 +1,285 @@
+import json
+import socket
+import threading
+import unittest
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from unittest import mock
+
+import requests
+from requests.exceptions import RetryError
+
+from instagrapi import Client
+from instagrapi.exceptions import (
+    ClientConnectionError,
+    ClientError,
+    ClientThrottledError,
+    PleaseWaitFewMinutes,
+)
+from instagrapi.mixins import private as private_mixin
+from instagrapi.mixins import public as public_mixin
+from tests.helpers import is_retryable_http_status_error
+
+
+@contextmanager
+def status_server(status_code, payload=None):
+    body = json.dumps(payload or {"message": "rate limited", "status": "fail"}).encode()
+
+    class Handler(BaseHTTPRequestHandler):
+        hits = 0
+
+        def do_GET(self):
+            type(self).hits += 1
+            self.send_response(status_code)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.send_header("Retry-After", "0")
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, format, *args):
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}/retry", Handler
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def response_with_json(status_code, payload, url):
+    response = requests.Response()
+    response.status_code = status_code
+    response.url = url
+    response.headers["Content-Type"] = "application/json"
+    response._content = json.dumps(payload).encode()
+    response.request = requests.Request("GET", url).prepare()
+    return response
+
+
+def retry_client(total=2):
+    client = Client(
+        request_timeout=0,
+        public_request_retries_timeout=0,
+        session_retry_total=total,
+        session_retry_backoff_factor=0,
+    )
+    client.delay_range = None
+    client.last_response_ts = 0
+    client.public.trust_env = False
+    client.private.trust_env = False
+    return client
+
+
+class RetryRegressionTestCase(unittest.TestCase):
+    def test_retry_strategies_return_final_status_response(self):
+        client = retry_client(total=2)
+        client.session_retry_backoff_factor = 0.25
+        client.session_retry_statuses = [429, 503]
+
+        for strategy in (
+            client._build_private_session_retry_strategy(),
+            client._build_public_session_retry_strategy(),
+        ):
+            with self.subTest(strategy=strategy):
+                self.assertFalse(strategy.raise_on_status)
+                self.assertEqual(strategy.total, 2)
+                self.assertEqual(strategy.backoff_factor, 0.25)
+                self.assertEqual(strategy.status_forcelist, [429, 503])
+                self.assertEqual(strategy.allowed_methods, ["GET", "POST"])
+
+    def test_legacy_retry_fallback_returns_final_status_response(self):
+        client = retry_client(total=2)
+
+        for module, builder_name in (
+            (private_mixin, "_build_private_session_retry_strategy"),
+            (public_mixin, "_build_public_session_retry_strategy"),
+        ):
+            calls = []
+
+            def legacy_retry(**kwargs):
+                calls.append(kwargs)
+                if "allowed_methods" in kwargs:
+                    raise TypeError("legacy urllib3")
+                return kwargs
+
+            with self.subTest(module=module.__name__):
+                with mock.patch.object(module, "Retry", side_effect=legacy_retry):
+                    strategy = getattr(client, builder_name)()
+
+                self.assertFalse(strategy.get("raise_on_status", True))
+                self.assertEqual(strategy["method_whitelist"], ["GET", "POST"])
+                self.assertEqual(len(calls), 2)
+
+    def test_private_session_returns_final_429_after_configured_attempts(self):
+        client = retry_client(total=2)
+
+        with status_server(429) as (url, handler):
+            response = client.private.get(url, timeout=1)
+
+        self.assertEqual(response.status_code, 429)
+        self.assertEqual(handler.hits, 3)
+
+    def test_public_request_maps_final_429_after_configured_attempts(self):
+        client = retry_client(total=2)
+
+        with status_server(429) as (url, handler):
+            with self.assertRaises(ClientThrottledError) as raised:
+                client._send_public_request(url, return_json=True, timeout=1)
+
+        self.assertEqual(raised.exception.response.status_code, 429)
+        self.assertEqual(handler.hits, 3)
+
+    def test_public_request_does_not_repeat_adapter_exhausted_429(self):
+        client = retry_client(total=2)
+
+        with status_server(429) as (url, handler):
+            with self.assertRaises(ClientThrottledError):
+                client.public_request(url, retries_count=2, retries_timeout=0)
+
+        self.assertEqual(handler.hits, 3)
+
+    def test_public_request_retains_outer_retries_when_transport_retries_are_disabled(self):
+        for total in (0, -1):
+            with self.subTest(total=total):
+                client = retry_client(total=total)
+
+                with status_server(429) as (url, handler):
+                    with self.assertRaises(ClientThrottledError):
+                        client.public_request(url, retries_count=2, retries_timeout=0)
+
+                self.assertEqual(handler.hits, 2)
+
+    def test_public_request_retains_outer_retries_for_curl_transport(self):
+        client = retry_client(total=2)
+        client.public_transport = "curl"
+        response = response_with_json(
+            429,
+            {"message": "rate limited", "status": "fail"},
+            "https://www.instagram.com/test/",
+        )
+        error = ClientThrottledError(response=response)
+
+        with mock.patch.object(client, "_send_public_request", side_effect=error) as send:
+            with self.assertRaises(ClientThrottledError):
+                client.public_request("https://www.instagram.com/test/", retries_count=2, retries_timeout=0)
+
+        self.assertEqual(send.call_count, 2)
+
+    def test_public_request_does_not_repeat_adapter_exhausted_503(self):
+        client = retry_client(total=2)
+
+        with status_server(503) as (url, handler):
+            with self.assertRaises(ClientError) as raised:
+                client.public_request(url, retries_count=2, retries_timeout=0)
+
+        self.assertEqual(raised.exception.response.status_code, 503)
+        self.assertEqual(handler.hits, 3)
+
+    def test_public_request_retries_status_not_handled_by_adapter(self):
+        client = retry_client(total=2)
+
+        with status_server(418) as (url, handler):
+            with self.assertRaises(ClientError) as raised:
+                client.public_request(url, retries_count=2, retries_timeout=0)
+
+        self.assertEqual(raised.exception.response.status_code, 418)
+        self.assertEqual(handler.hits, 2)
+
+    def test_public_request_retries_response_less_connection_error(self):
+        client = retry_client(total=2)
+        error = ClientConnectionError("connection exhausted")
+
+        with mock.patch.object(client, "_send_public_request", side_effect=error) as send:
+            with self.assertRaises(ClientConnectionError):
+                client.public_request("https://www.instagram.com/test/", retries_count=2, retries_timeout=0)
+
+        self.assertEqual(send.call_count, 2)
+
+    def test_public_stream_maps_final_429_before_returning(self):
+        client = retry_client(total=2)
+
+        with status_server(429) as (url, handler):
+            with self.assertRaises(ClientThrottledError) as raised:
+                client._send_public_request(url, stream=True, timeout=1)
+
+        self.assertTrue(raised.exception.response.raw.closed)
+        self.assertEqual(handler.hits, 3)
+
+    def test_public_stream_returns_open_success_response(self):
+        client = retry_client(total=0)
+
+        with status_server(200, {"status": "ok"}) as (url, _handler):
+            response = client._send_public_request(url, stream=True, timeout=1)
+            try:
+                self.assertEqual(response.status_code, 200)
+                self.assertFalse(response._content)
+            finally:
+                response.close()
+
+    def test_private_final_429_maps_to_client_throttled_error(self):
+        client = retry_client(total=0)
+        response = response_with_json(
+            429,
+            {"message": "rate limited", "status": "fail"},
+            "https://i.instagram.com/api/v1/test/",
+        )
+
+        with mock.patch.object(client.private, "get", return_value=response):
+            with self.assertRaises(ClientThrottledError) as raised:
+                client._send_private_request("test/")
+
+        self.assertIs(raised.exception.response, response)
+
+    def test_private_final_429_with_wait_message_maps_to_please_wait(self):
+        client = retry_client(total=0)
+        response = response_with_json(
+            429,
+            {"message": "Please wait a few minutes before you try again.", "status": "fail"},
+            "https://i.instagram.com/api/v1/test/",
+        )
+
+        with mock.patch.object(client.private, "get", return_value=response):
+            with self.assertRaises(PleaseWaitFewMinutes) as raised:
+                client._send_private_request("test/")
+
+        self.assertIs(raised.exception.response, response)
+
+    def test_public_connection_exhaustion_remains_client_connection_error(self):
+        client = retry_client(total=0)
+        probe = socket.socket()
+        probe.bind(("127.0.0.1", 0))
+        port = probe.getsockname()[1]
+        probe.close()
+
+        with self.assertRaises(ClientConnectionError):
+            client._send_public_request(f"http://127.0.0.1:{port}/", timeout=0.2)
+
+    def test_retryable_http_status_error_accepts_typed_status_and_legacy_retry_error(self):
+        response = response_with_json(
+            500,
+            {"status": "fail"},
+            "https://i.instagram.com/api/v1/media/configure_to_igtv/",
+        )
+        typed_error = ClientError(response=response)
+        legacy_error = RetryError("configure_to_igtv: too many 500 error responses")
+
+        self.assertTrue(is_retryable_http_status_error(typed_error, {500}, "configure_to_igtv"))
+        self.assertTrue(is_retryable_http_status_error(legacy_error, {500}, "configure_to_igtv"))
+
+    def test_retryable_http_status_error_rejects_wrong_status_or_endpoint(self):
+        cases = (
+            (400, "https://i.instagram.com/api/v1/media/configure_to_igtv/"),
+            (500, "https://i.instagram.com/api/v1/media/configure/"),
+        )
+
+        for status_code, url in cases:
+            with self.subTest(status_code=status_code, url=url):
+                response = response_with_json(status_code, {"status": "fail"}, url)
+                error = ClientError(response=response)
+
+                self.assertFalse(is_retryable_http_status_error(error, {500}, "configure_to_igtv"))


### PR DESCRIPTION
## Summary

- Return the final retryable HTTP response from urllib3 so existing private and public handlers can map it to typed instagrapi errors, including `ClientThrottledError` for 429 responses.
- Prevent the Requests transport from running a second outer retry package after adapter status retries are exhausted, while retaining outer retries when adapter retries are disabled or curl is used.
- Validate streamed responses before returning them, closing failed streams while leaving successful streams open for callers.
- Keep live-test compatibility with both typed response errors and legacy `RetryError` behavior, and document the retry-layer contract.

## Test plan

- `pytest -q tests/regression`: 782 passed, 3 skipped, 37 subtests passed.
- `pytest -q tests/regression/test_retry.py`: 17 passed, 8 subtests passed.
- Ruff lint and format checks passed.
- MkDocs strict build and all pre-commit hooks passed.
- Bandit high-severity scan passed for the changed production modules.
- Live Instagram integration targets were unavailable in this environment; the modified live-test modules passed static checks.

## Review

- Independent code review found no blocking issues.
- Retry-path coverage audit reached all identified changed branches after adding the two missing public-wrapper cases to regression tests and CI.
- Implementation-plan audit found no missing implementation items.

## Documentation

- `docs/usage-guide/interactions.md` documents that exhausted Requests status retries return the final response to instagrapi's typed exception mapping, avoid a duplicate public retry package, and preserve the existing outer loop when transport retries are disabled or curl is used.
- Existing exception-handling and rate-limit guides already cover `ClientThrottledError`, HTTP 429 backoff, and operational guidance.
- Documentation debt: none for this scoped retry fix.

Refs #2774
