### PR TITLE
v2.18.18 docs: capture login errors before CAA fallback overwrites them

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -32,6 +32,7 @@ export IG_PUBLIC_TRANSPORT_IMPERSONATE="chrome136"
 | --- | --- |
 | [`_common.py`](_common.py) | Shared login, proxy, session, and environment helpers used by the examples. |
 | [`session_login.py`](session_login.py) | Minimal session persistence and `sessionid` login sample. |
+| [`diagnose_login.py`](diagnose_login.py) | Capture sanitized HTTP diagnostics for password login, CAA fallback, and challenges. |
 | [`public_lookup.py`](public_lookup.py) | Public profile lookup with optional `public_transport="curl"`. |
 | [`download_user_media.py`](download_user_media.py) | Login, list recent media for a username, and download photos/videos/albums. |
 | [`monitor_user_content.py`](monitor_user_content.py) | Poll a small set of users for new posts and stories using a saved session. |
@@ -42,6 +43,38 @@ export IG_PUBLIC_TRANSPORT_IMPERSONATE="chrome136"
 | [`challenge_resolvers.py`](challenge_resolvers.py) | Email/SMS challenge resolver hooks. |
 | [`next_proxy.py`](next_proxy.py) | Example proxy rotation scaffold. |
 | [`download_all_medias.py`](download_all_medias.py) | Larger download script for account media. |
+
+## Login diagnostics
+
+Run [`diagnose_login.py`](diagnose_login.py) in the same Python environment and with the same
+`instagrapi` version as the failing script. It is standalone: downloading that one file is enough;
+keep your installed library version unchanged while collecting evidence.
+
+```bash
+python examples/diagnose_login.py --settings session.json --report login-diagnostic.json --relogin
+```
+
+If you downloaded the file outside the repository, use `python diagnose_login.py` with the same options.
+Point `--settings` at the settings file your script already uses. An existing file is loaded before login;
+otherwise a new client identity is created. Settings are saved even when login fails. `--relogin` tests
+password login even with an authorized saved session, preserving its device identifiers. Without it,
+the library can validate and reuse the saved session instead.
+
+The script prompts for username/password unless `IG_USERNAME`/`IG_PASSWORD` are set. Add `--proxy`
+to enter your usual proxy privately, or keep your existing `IG_PROXY`. Add `--two-factor` to enter a
+current 2FA code. It stops at the original challenge response without automatically resolving
+email/SMS challenges or changing passwords.
+
+It calls `login()` once, disables transport retries, and applies 10-second connect / 30-second
+read timeouts. The normal library login flow can make several requests, including a CAA fallback.
+Each response is summarized immediately, before another request can overwrite `last_json`.
+
+Share **only `login-diagnostic.json`**, after reviewing it. It contains fixed endpoint labels, HTTP
+statuses, content types, response sizes, and allowlisted error categories. Unknown messages and values
+become `other`; response bodies, full URLs, cookies, credentials, IDs, and challenge tokens are omitted.
+The separate **settings file is private** and contains session credentials. Both files are written with
+owner-only permissions on systems that support them. Exit code `1` is expected when login fails; the
+report is still written. Use the next observed failure rather than repeatedly retrying to collect logs.
 
 ## Public lookup
 

--- a/examples/diagnose_login.py
+++ b/examples/diagnose_login.py
@@ -1,0 +1,314 @@
+"""Capture shareable login diagnostics without exporting credentials or payloads.
+
+Download this file and run it with the same Python environment and instagrapi
+version as the failing script. Use --settings for its existing settings file,
+--proxy to enter the same proxy privately, and --relogin to test password login
+even if the settings already contain an authorized session. Only the report is
+intended for sharing; the settings file contains private session credentials.
+"""
+
+import argparse
+import contextlib
+import getpass
+import json
+import logging
+import os
+import platform
+import tempfile
+import warnings
+from importlib.metadata import version
+from pathlib import Path
+from urllib.parse import urlsplit
+
+from instagrapi import Client
+from instagrapi.exceptions import ChallengeRequired
+
+ERROR_TYPES = {
+    "bad_password",
+    "challenge_required",
+    "checkpoint_required",
+    "login_required",
+    "two_factor_required",
+    "rate_limit_error",
+    "sentry_block",
+    "feedback_required",
+}
+STEPS = {
+    "select_verify_method",
+    "verify_code",
+    "submit_phone",
+    "submit_phone_number",
+    "verify_email",
+    "verify_sms",
+    "change_password",
+    "force_set_new_password",
+    "delta_login_review",
+    "select_contact_point_recovery",
+}
+CONTENT_TYPES = {"application/json", "text/json", "text/html", "text/plain"}
+
+
+def allowed(value, choices):
+    """Never copy arbitrary server strings, even from normally harmless fields."""
+    if value is None:
+        return None
+    return value if isinstance(value, str) and value in choices else "other"
+
+
+def message_category(value):
+    if not isinstance(value, str) or not value:
+        return None
+    text = value.lower()
+    if "email" in text and "back into your account" in text:
+        return "email_account_recovery"
+    for marker in (
+        "challenge_required",
+        "login_required",
+        "two_factor_required",
+        "feedback_required",
+        "please wait a few minutes",
+        "too many requests",
+        "bad password",
+        "incorrect password",
+        "manual verification",
+    ):
+        if marker in text:
+            return marker.replace(" ", "_")
+    return "other"
+
+
+def challenge_path(value):
+    if not isinstance(value, str) or not value:
+        return None
+    for prefix in ("/api/v1/challenge/", "/api/challenge/", "/challenge/", "/auth_platform/"):
+        if value.startswith(prefix):
+            return prefix + "<redacted>"
+    return "other"
+
+
+def summarize_json(data):
+    if not isinstance(data, dict):
+        return {"type": type(data).__name__}
+    challenge = data.get("challenge")
+    if not isinstance(challenge, dict):
+        challenge = {}
+    native = challenge.get("native_flow")
+    return {
+        "type": "dict",
+        "empty": not bool(data),
+        "message_category": message_category(data.get("message")),
+        "error_type": allowed(data.get("error_type"), ERROR_TYPES),
+        "status": allowed(data.get("status"), {"ok", "fail"}),
+        "step_name": allowed(data.get("step_name"), STEPS),
+        "bloks_action": allowed(data.get("bloks_action"), {"com.bloks.www.ig.challenge.redirect.async"}),
+        "challenge_native_flow": native if isinstance(native, bool) or native is None else "other",
+        "challenge_api_path": challenge_path(challenge.get("api_path")),
+    }
+
+
+def endpoint_label(path):
+    for suffix, label in (
+        ("/accounts/login/", "accounts/login"),
+        ("/accounts/two_factor_login/", "accounts/two_factor_login"),
+        ("/accounts/current_user/", "accounts/current_user"),
+        ("send_login_request/", "caa/send_login_request"),
+        ("process_client_data/", "caa/process_client_data"),
+        ("oauth_token.fetch/", "caa/oauth_token_fetch"),
+        ("/launcher/sync/", "launcher/sync"),
+        ("/qe/sync/", "qe/sync"),
+        ("/feed/timeline/", "feed/timeline"),
+        ("/feed/reels_tray/", "feed/reels_tray"),
+    ):
+        if path.endswith(suffix):
+            return label
+    for marker in ("challenge", "attestation", "usdid", "bloks"):
+        if marker in path:
+            return marker
+    return "other"
+
+
+def summarize_response(response):
+    url = urlsplit(response.url)
+    try:
+        body = summarize_json(response.json())
+    except ValueError:
+        body = {"type": "non_json"}
+    return {
+        "host": allowed(url.hostname, {"i.instagram.com", "b.i.instagram.com", "www.instagram.com"}),
+        "endpoint": endpoint_label(url.path),
+        "method": allowed(response.request.method if response.request else None, {"GET", "POST"}),
+        "http_status": response.status_code,
+        "content_type": allowed(response.headers.get("Content-Type", "").split(";", 1)[0], CONTENT_TYPES),
+        "body_bytes": len(response.content),
+        "json": body,
+    }
+
+
+@contextlib.contextmanager
+def quiet_library():
+    """Library logs and exception messages can contain raw responses or proxies."""
+    previous = logging.root.manager.disable
+    logging.disable(logging.CRITICAL)
+    try:
+        with open(os.devnull, "w") as sink, warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            with contextlib.redirect_stdout(sink), contextlib.redirect_stderr(sink):
+                yield
+    finally:
+        logging.disable(previous)
+
+
+def manual_checkpoint(*args, **kwargs):
+    raise ChallengeRequired("Manual verification required; no automatic input in diagnostic mode")
+
+
+def diagnose(client, username, password, *, relogin=False, verification_code=""):
+    """Observe one login() call; snapshot each response before fallback mutates state."""
+    report = {"outcome": "error", "responses": []}
+
+    def capture(response, *args, **kwargs):
+        report["responses"].append(summarize_response(response))
+        return response
+
+    def stop_on_error(client, exc):
+        # Legacy challenge resolution can create unobserved requests.Session objects.
+        # Re-raise the original error; login() can still perform its CAA fallback.
+        raise exc
+
+    sessions = (client.private, client.public)
+    previous_handler = client.handle_exception
+    client.handle_exception = stop_on_error
+    for session in sessions:
+        session.hooks.setdefault("response", []).append(capture)
+    try:
+        with quiet_library():
+            try:
+                result = client.login(username, password, relogin=relogin, verification_code=verification_code)
+                report["outcome"] = "success" if result else "false_return"
+            except (Exception, KeyboardInterrupt) as exc:
+                report["exception"] = {**summarize_json(vars(exc)), "type": type(exc).__name__}
+    finally:
+        client.handle_exception = previous_handler
+        for session in sessions:
+            session.hooks["response"].remove(capture)
+    report["last_json"] = summarize_json(client.last_json)
+    return report
+
+
+def write_private_json(path, data):
+    """Replace atomically with a mode-0600 file, including when a file already exists."""
+    temporary = None
+    try:
+        with tempfile.NamedTemporaryFile(mode="w", encoding="utf-8", dir=path.parent, delete=False) as stream:
+            temporary = Path(stream.name)
+            json.dump(data, stream, indent=2, ensure_ascii=True)
+            stream.write("\n")
+        temporary.replace(path)
+    finally:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
+
+
+def bound_requests(session):
+    original = session.request
+
+    def request(*args, **kwargs):
+        if kwargs.get("timeout") is None:
+            kwargs["timeout"] = (10, 30)
+        return original(*args, **kwargs)
+
+    session.request = request
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--settings",
+        type=Path,
+        default=Path(os.getenv("IG_SESSION_FILE", "session.json")),
+        help="private settings file to load and update, including after failure (default: session.json)",
+    )
+    parser.add_argument(
+        "--report",
+        type=Path,
+        default=Path("login-diagnostic.json"),
+        help="sanitized JSON report to share (default: login-diagnostic.json)",
+    )
+    parser.add_argument(
+        "--relogin", action="store_true", help="test password login even with an authorized saved session"
+    )
+    parser.add_argument("--proxy", action="store_true", help="prompt privately for the same proxy used by your script")
+    parser.add_argument("--two-factor", action="store_true", help="prompt privately for a current 2FA code")
+    args = parser.parse_args(argv)
+    settings_path, report_path = args.settings.resolve(), args.report.resolve()
+    if settings_path == report_path:
+        parser.error("--settings and --report must be different files")
+
+    client = None
+    report = {"outcome": "setup_error", "responses": []}
+    report_written = True
+    try:
+        settings = json.loads(settings_path.read_text()) if settings_path.exists() else {}
+        if not isinstance(settings, dict):
+            raise ValueError("Settings must be a JSON object")
+        report["environment"] = {
+            "instagrapi": version("instagrapi"),
+            "python": platform.python_version(),
+            "os": platform.system(),
+            "settings_loaded": settings_path.exists(),
+            "relogin": args.relogin,
+            "transport_retries": 0,
+            "connect_timeout_seconds": 10,
+            "read_timeout_seconds": 30,
+        }
+        # Check report destination and settings permissions before making requests.
+        write_private_json(report_path, report)
+        write_private_json(settings_path, settings)
+        username = os.getenv("IG_USERNAME") or input("Instagram username: ").strip()
+        password = os.getenv("IG_PASSWORD") or getpass.getpass("Instagram password: ")
+        proxy = getpass.getpass("Proxy URL: ") if args.proxy else os.getenv("IG_PROXY")
+        code = getpass.getpass("Current 2FA code: ") if args.two_factor else ""
+        if not username or not password:
+            raise ValueError("Credentials are required")
+        with quiet_library():
+            client = Client(
+                settings={**settings, "session_retry_total": 0, "public_request_retries_count": 1}, proxy=proxy
+            )
+        client.challenge_code_handler = manual_checkpoint
+        client.change_password_handler = manual_checkpoint
+        for session in (client.private, client.public):
+            bound_requests(session)
+        report["environment"]["proxy_configured"] = bool(proxy)
+        report["environment"]["two_factor_code_supplied"] = bool(code)
+        print("Running one login attempt; please wait...")
+        report.update(diagnose(client, username, password, relogin=args.relogin, verification_code=code))
+    except (Exception, KeyboardInterrupt) as exc:
+        report["exception"] = {"type": type(exc).__name__}
+    finally:
+        if client is not None:
+            try:
+                updated_settings = client.get_settings()
+                for key in ("session_retry_total", "public_request_retries_count"):
+                    if key in settings:
+                        updated_settings[key] = settings[key]
+                    else:
+                        updated_settings.pop(key, None)
+                write_private_json(settings_path, updated_settings)
+                report["settings_saved"] = True
+            except Exception as exc:
+                report["settings_saved"] = False
+                report["settings_save_error"] = type(exc).__name__
+        try:
+            write_private_json(report_path, report)
+        except Exception as exc:
+            print(f"Could not write the report ({type(exc).__name__}).")
+            report_written = False
+    if not report_written:
+        return 1
+    print("Report saved to --report (default: login-diagnostic.json). Review it before sharing.")
+    print("Keep the --settings file private: it contains session credentials.")
+    return 0 if report["outcome"] == "success" and report.get("settings_saved") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/regression/test_login_diagnostic.py
+++ b/tests/regression/test_login_diagnostic.py
@@ -207,20 +207,24 @@ def test_report_cannot_overwrite_settings(diagnostic, monkeypatch, tmp_path):
     client.assert_not_called()
 
 
-def test_library_stdout_logs_and_exception_text_are_not_exported(diagnostic, capsys):
+def test_library_stdout_logs_and_exception_text_are_not_exported(diagnostic, capsys, caplog):
     client = Client()
+    # Test blanket output suppression independently of the credential fixtures.
+    output_marker = "synthetic-library-output"
 
     def reject(*args, **kwargs):
-        print(SECRET)
-        logging.getLogger("instagrapi").error(SECRET)
-        raise RuntimeError(SECRET)
+        print(output_marker)
+        logging.getLogger("instagrapi").error(output_marker)
+        raise RuntimeError(output_marker)
 
     client.login = reject
     report = diagnostic.diagnose(client, "synthetic-user", SECRET)
     assert report["exception"]["type"] == "RuntimeError"
     assert SECRET not in json.dumps(report)
+    assert output_marker not in json.dumps(report)
     streams = capsys.readouterr()
     assert SECRET not in streams.out + streams.err
+    assert output_marker not in streams.out + streams.err + caplog.text
 
 
 def test_interruption_still_saves_settings_and_report(diagnostic, monkeypatch, tmp_path):

--- a/tests/regression/test_login_diagnostic.py
+++ b/tests/regression/test_login_diagnostic.py
@@ -1,0 +1,271 @@
+import importlib.util
+import json
+import logging
+import stat
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+import requests
+
+from instagrapi import Client
+
+SCRIPT = Path(__file__).resolve().parents[2] / "examples" / "diagnose_login.py"
+LOGIN = "https://i.instagram.com/api/v1/accounts/login/"
+CAA = "https://b.i.instagram.com/api/v1/bloks/async_action/com.bloks.www.bloks.caa.login.async.send_login_request/"
+SECRET = "DO_NOT_SHARE_test_secret_12345"
+
+
+@pytest.fixture
+def diagnostic():
+    assert SCRIPT.exists(), "The standalone login diagnostic script is missing"
+    spec = importlib.util.spec_from_file_location("login_diagnostic", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def response(request, status, body, content_type="application/json"):
+    result = requests.Response()
+    result.status_code = status
+    result.reason = "Bad Request" if status == 400 else "Too Many Requests"
+    result.request = request
+    result.url = request.url
+    result._content = body
+    result.encoding = "utf-8"
+    result.headers["Content-Type"] = content_type
+    return result
+
+
+def failing_login(monkeypatch, caa_body, content_type):
+    client = Client()
+    client.private.trust_env = False
+    client.public.trust_env = False
+    client.caa_aac = '{"aaccs":"synthetic-context"}'
+    client.pre_login_flow = Mock(return_value=True)
+    client.password_encrypt = Mock(return_value="#PWD_INSTAGRAM:4:1:synthetic")
+    client.bloks_caa_login_prepare = Mock(return_value=True)
+    calls = []
+
+    def send(adapter, request, **kwargs):
+        calls.append(request.url)
+        assert request.method == "POST"
+        if calls == [LOGIN]:
+            body = {
+                "message": "We can send you an email to help you get back into your account. " + SECRET,
+                "error_type": "bad_password",
+                "status": "fail",
+                "username": SECRET,
+                "challenge_context": SECRET,
+            }
+            return response(request, 400, json.dumps(body).encode())
+        assert calls == [LOGIN, CAA], "Unexpected request in offline test"
+        return response(request, 429, caa_body, content_type)
+
+    monkeypatch.setattr(requests.adapters.HTTPAdapter, "send", send)
+    return client, calls
+
+
+@pytest.mark.parametrize(
+    ("body", "content_type", "body_kind", "empty"),
+    [
+        (b"", "text/plain", "non_json", True),
+        (b"<html>private response</html>", "text/html", "non_json", True),
+        (b"{}", "application/json", "dict", True),
+        (b'{"message":"limit","status":"fail"}', "application/json", "dict", False),
+    ],
+)
+def test_captures_original_and_caa_before_last_json_is_overwritten(
+    diagnostic, monkeypatch, body, content_type, body_kind, empty
+):
+    client, calls = failing_login(monkeypatch, body, content_type)
+    previous_logging = logging.root.manager.disable
+
+    report = diagnostic.diagnose(client, "synthetic-user", SECRET)
+
+    assert calls == [LOGIN, CAA]
+    assert report["outcome"] == "error"
+    assert report["exception"]["type"] == "BadPassword"
+    assert report["exception"]["error_type"] == "bad_password"
+    assert report["last_json"]["empty"] is empty
+    assert [(item["endpoint"], item["http_status"]) for item in report["responses"]] == [
+        ("accounts/login", 400),
+        ("caa/send_login_request", 429),
+    ]
+    assert report["responses"][0]["json"]["error_type"] == "bad_password"
+    assert report["responses"][1]["json"]["type"] == body_kind
+    assert SECRET not in json.dumps(report)
+    assert "private response" not in json.dumps(report)
+    assert logging.root.manager.disable == previous_logging
+    assert client.private.hooks["response"] == []
+
+
+def test_response_summary_never_copies_untrusted_strings(diagnostic):
+    req = requests.Request("POST", f"https://i.instagram.com/api/v1/challenge/{SECRET}/?token={SECRET}").prepare()
+    payload = {
+        "message": SECRET,
+        "status": SECRET,
+        "error_type": SECRET,
+        "step_name": SECRET,
+        "bloks_action": SECRET,
+        "challenge": {"native_flow": SECRET, "api_path": f"/challenge/{SECRET}/", "challenge_context": SECRET},
+        "authorization_data": {"sessionid": SECRET},
+    }
+    raw = response(req, 400, json.dumps(payload).encode(), SECRET)
+    raw.headers["Set-Cookie"] = f"sessionid={SECRET}"
+    raw.headers["Location"] = f"https://instagram.com/{SECRET}"
+    summary = diagnostic.summarize_response(raw)
+
+    assert SECRET not in json.dumps(summary)
+    assert summary["endpoint"] == "challenge"
+    assert summary["json"]["challenge_api_path"] == "/challenge/<redacted>"
+    assert summary["json"]["error_type"] == "other"
+    assert summary["content_type"] == "other"
+    assert "Set-Cookie" not in summary
+
+
+def test_native_challenge_fields_remain_useful(diagnostic):
+    summary = diagnostic.summarize_json(
+        {
+            "message": "challenge_required",
+            "status": "fail",
+            "challenge": {"native_flow": True, "api_path": f"/api/v1/challenge/{SECRET}/"},
+        }
+    )
+    assert summary["message_category"] == "challenge_required"
+    assert summary["challenge_native_flow"] is True
+    assert summary["challenge_api_path"] == "/api/v1/challenge/<redacted>"
+    assert SECRET not in json.dumps(summary)
+
+
+@pytest.mark.parametrize("custom_handler", [False, True])
+def test_stops_before_automatic_challenge_requests_and_restores_handler(diagnostic, monkeypatch, custom_handler):
+    client = Client(settings={"session_retry_total": 0, "request_timeout": 0})
+    client.pre_login_flow = Mock(return_value=True)
+    client.password_encrypt = Mock(return_value="synthetic")
+    original_handler = Mock(side_effect=RuntimeError("must not call user handler")) if custom_handler else None
+    client.handle_exception = original_handler
+    calls = []
+
+    def send(adapter, request, **kwargs):
+        calls.append(request.url)
+        assert calls == [LOGIN], "Diagnostic must not resolve a challenge automatically"
+        body = {
+            "message": "challenge_required",
+            "status": "fail",
+            "challenge": {"api_path": f"/challenge/123/{SECRET}/"},
+        }
+        return response(request, 400, json.dumps(body).encode())
+
+    monkeypatch.setattr(requests.adapters.HTTPAdapter, "send", send)
+    report = diagnostic.diagnose(client, "synthetic-user", SECRET)
+
+    assert calls == [LOGIN]
+    assert report["exception"]["type"] == "ChallengeRequired"
+    assert report["responses"][0]["json"]["challenge_api_path"] == "/challenge/<redacted>"
+    assert client.handle_exception is original_handler
+    if custom_handler:
+        original_handler.assert_not_called()
+    assert SECRET not in json.dumps(report)
+
+
+def test_main_saves_private_settings_and_sanitized_report_after_failure(diagnostic, monkeypatch, tmp_path, capsys):
+    client, _ = failing_login(monkeypatch, b"", "text/html")
+    client.private.cookies.set("synthetic_private_cookie", SECRET)
+    factory = Mock(return_value=client)
+    monkeypatch.setattr(diagnostic, "Client", factory)
+    monkeypatch.setenv("IG_USERNAME", "synthetic-user")
+    monkeypatch.setenv("IG_PASSWORD", SECRET)
+    monkeypatch.delenv("IG_PROXY", raising=False)
+    monkeypatch.delenv("IG_SESSION_FILE", raising=False)
+    settings = tmp_path / "session.json"
+    output = tmp_path / "report.json"
+    settings.write_text(json.dumps({"uuids": {"uuid": "saved-device"}}))
+
+    code = diagnostic.main(["--settings", str(settings), "--report", str(output)])
+
+    assert code == 1
+    assert factory.call_args.kwargs["settings"]["uuids"]["uuid"] == "saved-device"
+    assert json.loads(output.read_text())["exception"]["type"] == "BadPassword"
+    assert SECRET not in output.read_text()
+    assert SECRET in settings.read_text()
+    assert stat.S_IMODE(settings.stat().st_mode) == 0o600
+    assert stat.S_IMODE(output.stat().st_mode) == 0o600
+    streams = capsys.readouterr()
+    assert SECRET not in streams.out + streams.err
+
+
+def test_report_cannot_overwrite_settings(diagnostic, monkeypatch, tmp_path):
+    client = Mock()
+    monkeypatch.setattr(diagnostic, "Client", client)
+    path = tmp_path / "session.json"
+    path.write_text(SECRET)
+    with pytest.raises(SystemExit) as exc:
+        diagnostic.main(["--settings", str(path), "--report", str(path)])
+    assert exc.value.code == 2
+    assert path.read_text() == SECRET
+    client.assert_not_called()
+
+
+def test_library_stdout_logs_and_exception_text_are_not_exported(diagnostic, capsys):
+    client = Client()
+
+    def reject(*args, **kwargs):
+        print(SECRET)
+        logging.getLogger("instagrapi").error(SECRET)
+        raise RuntimeError(SECRET)
+
+    client.login = reject
+    report = diagnostic.diagnose(client, "synthetic-user", SECRET)
+    assert report["exception"]["type"] == "RuntimeError"
+    assert SECRET not in json.dumps(report)
+    streams = capsys.readouterr()
+    assert SECRET not in streams.out + streams.err
+
+
+def test_interruption_still_saves_settings_and_report(diagnostic, monkeypatch, tmp_path):
+    client = Client()
+    client.login = Mock(side_effect=KeyboardInterrupt())
+    monkeypatch.setattr(diagnostic, "Client", Mock(return_value=client))
+    monkeypatch.setenv("IG_USERNAME", "synthetic-user")
+    monkeypatch.setenv("IG_PASSWORD", SECRET)
+    monkeypatch.delenv("IG_PROXY", raising=False)
+    settings = tmp_path / "session.json"
+    output = tmp_path / "report.json"
+
+    assert diagnostic.main(["--settings", str(settings), "--report", str(output), "--relogin"]) == 1
+    report = json.loads(output.read_text())
+    assert report["exception"]["type"] == "KeyboardInterrupt"
+    assert report["settings_saved"] is True
+    assert json.loads(settings.read_text())["uuids"]["uuid"] == client.uuid
+    assert client.login.call_args.kwargs["relogin"] is True
+
+
+def test_invalid_report_destination_stops_before_login(diagnostic, monkeypatch, tmp_path):
+    factory = Mock()
+    monkeypatch.setattr(diagnostic, "Client", factory)
+    settings = tmp_path / "session.json"
+    settings.write_text('{"uuids": {"uuid": "keep-existing"}}')
+    original = settings.read_bytes()
+    output = tmp_path / "missing-directory" / "report.json"
+
+    assert diagnostic.main(["--settings", str(settings), "--report", str(output)]) == 1
+    assert settings.read_bytes() == original
+    factory.assert_not_called()
+
+
+@pytest.mark.parametrize("retry_settings", [{}, {"session_retry_total": 4, "public_request_retries_count": 2}])
+def test_diagnostic_retry_overrides_do_not_change_saved_preferences(diagnostic, monkeypatch, tmp_path, retry_settings):
+    client = Client(settings={"session_retry_total": 0, "public_request_retries_count": 1})
+    client.login = Mock(return_value=True)
+    monkeypatch.setattr(diagnostic, "Client", Mock(return_value=client))
+    monkeypatch.setenv("IG_USERNAME", "synthetic-user")
+    monkeypatch.setenv("IG_PASSWORD", SECRET)
+    monkeypatch.delenv("IG_PROXY", raising=False)
+    settings = tmp_path / "session.json"
+    settings.write_text(json.dumps(retry_settings))
+
+    assert diagnostic.main(["--settings", str(settings), "--report", str(tmp_path / "report.json")]) == 0
+    saved = json.loads(settings.read_text())
+    for key in ("session_retry_total", "public_request_retries_count"):
+        assert saved.get(key) == retry_settings.get(key)


### PR DESCRIPTION
When password login falls back to CAA and that request fails, `last_json` can lose the original login error. Add a standalone `examples/diagnose_login.py` that captures a sanitized summary of each HTTP response before the next request overwrites it, so issue reporters can distinguish the initial failure from the fallback failure.

The script works with the user's existing installation and saved device settings. It saves settings and the report after failure or interruption, suppresses raw library output, and stops automatic challenge resolution. Reports contain fixed endpoint labels and allowlisted error categories; credentials, cookies, payloads, full URLs, and challenge tokens are omitted. Usage is documented in `examples/README.md`.

Validation: 797 regression tests passed, 3 skipped; Ruff, Bandit, strict MkDocs build, and all pre-commit hooks passed. Fifteen diagnostic cases cover real login/CAA code with synthetic HTTP responses, sanitization, settings persistence, interruption, and challenge handling. An independent review found no remaining issues. A live Linux control completed password login and preserved device identifiers; the reported CAA 429 was reproduced only with synthetic responses. Termux execution remains untested.

Related to #2778. This adds diagnostics; the reported Instagram login rejection remains unresolved.
