### PR TITLE
feat: add optional HTTP/2 private transport

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -109,6 +109,24 @@ jobs:
             tests/regression/test_upload.py::UploadRegressionTestCase \
             tests/regression/test_retry.py::RetryRegressionTestCase
 
+  test-curl-transport:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ "3.10", "3.14" ]
+        curl-cffi: [ "curl_cffi==0.15.0", "curl_cffi" ]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install optional transport and wire test dependencies
+        run: python -m pip install ".[curl]" "${{ matrix.curl-cffi }}" pytest "h2>=4.3,<5" "cryptography>=46,<47"
+      - name: Verify dependencies and run real TLS/HTTP2 tests
+        run: |
+          python -c "import curl_cffi, h2, cryptography"
+          pytest -q tests/regression/test_private_transport.py tests/regression/test_private_transport_wire.py
+
   build-docs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/master')

--- a/README.md
+++ b/README.md
@@ -30,19 +30,21 @@ Support **Python 3.10+**
 pip install instagrapi
 ```
 
-Optional public web TLS impersonation support is available as an extra:
+Optional public web TLS impersonation and private HTTP/2 transports are available as an extra:
 
 ```bash
 pip install "instagrapi[curl]"
 ```
 
-Use it only for public web endpoints that are sensitive to browser TLS fingerprints:
+For public web endpoints that are sensitive to browser TLS fingerprints:
 
 ```python
 cl = Client(public_transport="curl", public_transport_impersonate="chrome136")
 ```
 
 See the [public transport guide](docs/usage-guide/public-transport.md) for live comparison results and caveats.
+
+For private mobile API requests, select `Client(private_transport="curl")` separately. See the [private HTTP/2 transport guide](docs/usage-guide/interactions.md#private-http2-transport) for saved-session setup, requirements and limitations.
 
 TLS certificate verification is enabled by default. For a trusted debugging MITM proxy, prefer `Client(tls_verify="/path/to/proxy-ca.pem")`; use `Client(tls_verify=False)` only for temporary local debugging because it allows session interception.
 

--- a/docs/usage-guide/interactions.md
+++ b/docs/usage-guide/interactions.md
@@ -61,6 +61,7 @@ print(cl.user_info(cl.user_id))
 | session\_retry\_total | Transport-level retry count for `public` and `private` sessions
 | session\_retry\_backoff\_factor | Backoff factor for transport-level retries
 | public\_transport | Public web transport: `requests` by default, or `curl` when `instagrapi[curl]` is installed
+| private\_transport | Private mobile API transport: `requests` by default, or `curl` for HTTP/2 with h2-only ALPN
 | public\_transport\_impersonate | Browser fingerprint used by the optional curl public transport
 | tls\_verify | TLS certificate verification: `True` by default, `False` for temporary trusted MITM debugging, or a CA bundle path
 
@@ -116,6 +117,7 @@ settings = {
     "session_retry_backoff_factor": 2,
     "session_retry_statuses": [429, 500, 502, 503, 504],
     "public_transport": "requests",
+    "private_transport": "requests",
     "public_transport_impersonate": "chrome136",
     "tls_verify": True,
 }
@@ -204,8 +206,27 @@ Then opt in explicitly:
 cl = Client(public_transport="curl", public_transport_impersonate="chrome136")
 ```
 
-The default remains `public_transport="requests"`. Private mobile API requests still use the regular mobile session.
+The default remains `public_transport="requests"`. Configure private mobile API requests separately with `private_transport`.
 See [Public Transport](public-transport.md) for live comparison results and caveats.
+
+### Private HTTP/2 transport
+
+Install `instagrapi[curl]` and use `Client(private_transport="curl")` to send private mobile API requests over HTTP/2 with an ALPN offer containing only `h2`. This option also applies to the existing CAA login flow. It preserves the mobile request headers and the account's device settings.
+
+```python
+cl = Client(settings=saved_settings, proxy=proxy_url)
+cl.set_retry_config(private_transport="curl")
+cl.login(username, password)
+cl.dump_settings("settings.json")
+```
+
+The transport selection is saved in settings. Restoring settings also restores their saved transport, taking precedence over the constructor option; call `cl.set_retry_config(private_transport="curl")` afterwards to switch it. Public and GraphQL transports have their own configuration. The default private transport remains `requests`; loading older settings without a transport value preserves an explicitly selected transport.
+
+The curl private transport requires `curl_cffi>=0.15.0` and libcurl 8.10 or newer. With older libcurl versions, requesting HTTP/2 can still offer both `h2` and `http/1.1` during TLS negotiation. See the [libcurl HTTP version documentation](https://curl.se/libcurl/c/CURLOPT_HTTP_VERSION.html).
+
+This transport preserves requests' cookie jar, proxy selection, TLS verification, client certificates and redirects. Responses and iterable request bodies are buffered in memory, including when a response is requested with `stream=True`. Response decompression is handled by requests/urllib3. A numeric timeout is curl's total transfer budget; a `(connect, read)` tuple of numbers supplies a connection budget and a total budget of their sum. Use `timeout=None` for no timeout; tuples containing `None` and `urllib3.util.Timeout` objects are rejected before sending a request.
+
+Private curl requests are sent once at the adapter level: `session_retry_total`, `session_retry_backoff_factor` and `session_retry_statuses` do not enable curl retries. HTTP 429 and connection failures reach the existing exception handling. Login routing and challenge handling follow the existing library flow; enabling the transport does not remove account, proxy or verification restrictions.
 
 ### Private mobile headers
 

--- a/docs/usage-guide/public-transport.md
+++ b/docs/usage-guide/public-transport.md
@@ -24,8 +24,8 @@ from instagrapi import Client
 cl = Client(public_transport="curl", public_transport_impersonate="chrome136")
 ```
 
-Private mobile API requests still use the regular mobile session. The curl transport only changes the public web
-session.
+`public_transport` configures the public web session. Private mobile API requests use `requests` by default and can
+separately opt into [private HTTP/2 transport](interactions.md#private-http2-transport) with `private_transport="curl"`.
 
 ## Live Comparison
 

--- a/instagrapi/mixins/auth.py
+++ b/instagrapi/mixins/auth.py
@@ -634,6 +634,7 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
             ),
             session_retry_statuses=self.settings.get("session_retry_statuses", self.session_retry_statuses),
             public_transport=self.settings.get("public_transport"),
+            private_transport=self.settings.get("private_transport"),
             public_transport_impersonate=self.settings.get("public_transport_impersonate"),
         )
 
@@ -967,6 +968,7 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
             "session_retry_backoff_factor": self.session_retry_backoff_factor,
             "session_retry_statuses": self.session_retry_statuses,
             "public_transport": self.public_transport,
+            "private_transport": self.private_transport,
             "public_transport_impersonate": self.public_transport_impersonate,
             "tls_verify": self.tls_verify,
         }
@@ -1050,7 +1052,10 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
         session_retry_statuses: list = None,
         public_transport: Optional[Literal["requests", "curl"]] = None,
         public_transport_impersonate: str = None,
+        private_transport: Optional[Literal["requests", "curl"]] = None,
     ) -> bool:
+        if private_transport is not None:
+            private_transport = self._normalize_private_transport(private_transport)
         if request_timeout is not None:
             self.request_timeout = request_timeout
         if public_request_retries_count is not None:
@@ -1074,7 +1079,7 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
             self.public.headers["User-Agent"] = self.public_user_agent
 
         self._configure_public_session_retry()
-        self._configure_private_session_retry()
+        self._configure_private_session_retry(private_transport=private_transport)
 
         if self.settings is not None:
             self.settings.update(
@@ -1086,6 +1091,7 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
                     "session_retry_backoff_factor": self.session_retry_backoff_factor,
                     "session_retry_statuses": self.session_retry_statuses,
                     "public_transport": self.public_transport,
+                    "private_transport": self.private_transport,
                     "public_transport_impersonate": self.public_transport_impersonate,
                 }
             )

--- a/instagrapi/mixins/private.py
+++ b/instagrapi/mixins/private.py
@@ -135,6 +135,7 @@ class PrivateRequestMixin:
     session_retry_total = 3
     session_retry_backoff_factor = 2
     session_retry_statuses = [429, 500, 502, 503, 504]
+    private_transport = "requests"
     domain = config.API_DOMAIN
     last_response = None
     last_json = {}
@@ -143,6 +144,9 @@ class PrivateRequestMixin:
         session = requests.Session()
         self.private = session
         self.private.verify = getattr(self, "tls_verify", True)
+        self.private_transport = self._normalize_private_transport(
+            kwargs.pop("private_transport", self.private_transport)
+        )
         self.email = kwargs.pop("email", None)
         self.phone_number = kwargs.pop("phone_number", None)
         self.request_timeout = kwargs.pop("request_timeout", getattr(self, "request_timeout", self.request_timeout))
@@ -185,10 +189,30 @@ class PrivateRequestMixin:
                 raise_on_status=False,
             )
 
-    def _configure_private_session_retry(self):
-        adapter = HTTPAdapter(max_retries=self._build_private_session_retry_strategy())
+    @staticmethod
+    def _normalize_private_transport(private_transport):
+        if private_transport not in {"requests", "curl"}:
+            raise ValueError("private_transport must be 'requests' or 'curl'")
+        return private_transport
+
+    def _configure_private_session_retry(self, private_transport=None):
+        private_transport = self.private_transport if private_transport is None else private_transport
+        if private_transport == "curl":
+            if getattr(self, "_private_adapter_transport", None) == "curl":
+                return
+            from instagrapi.transports import create_curl_h2_adapter
+
+            adapter = create_curl_h2_adapter()
+        else:
+            adapter = HTTPAdapter(max_retries=self._build_private_session_retry_strategy())
+        previous = set(self.private.adapters.values())
         self.private.mount("https://", adapter)
         self.private.mount("http://", adapter)
+        self.private_transport = private_transport
+        self._private_adapter_transport = private_transport
+        for old_adapter in previous:
+            if old_adapter not in self.private.adapters.values():
+                old_adapter.close()
 
     def small_delay(self):
         """

--- a/instagrapi/transports.py
+++ b/instagrapi/transports.py
@@ -1,0 +1,144 @@
+"""Optional transports for the requests sessions used by Client."""
+
+import os
+import re
+from email.message import Message
+from io import BytesIO
+from types import SimpleNamespace
+from urllib.parse import urlsplit
+
+from requests import exceptions
+from requests.adapters import HTTPAdapter
+from requests.utils import select_proxy
+from urllib3._collections import HTTPHeaderDict
+from urllib3.response import HTTPResponse
+
+
+def create_curl_h2_adapter():
+    return _CurlH2Adapter()
+
+
+class _CurlH2Adapter(HTTPAdapter):
+    """Buffered private API transport with h2-only ALPN and no request retries.
+
+    Requests owns redirects, cookies and decompression. Curl owns the persistent
+    connection pool; browser impersonation and its extra headers are disabled.
+    """
+
+    def __init__(self):
+        try:
+            import curl_cffi
+            from curl_cffi import CurlHttpVersion, CurlOpt, ffi
+            from curl_cffi import requests as curl_requests
+        except ImportError as exc:
+            raise RuntimeError(
+                "curl private transport requires the optional curl extra: pip install instagrapi[curl]"
+            ) from exc
+
+        version = re.search(r"libcurl/(\d+)\.(\d+)\.(\d+)", curl_cffi.__curl_version__)
+        if not version or tuple(map(int, version.groups())) < (8, 10, 0):
+            raise RuntimeError("curl private transport requires libcurl >= 8.10.0 for h2-only ALPN")
+
+        super().__init__(max_retries=0)
+        self._curl_requests = curl_requests
+        self._http2 = CurlHttpVersion.V2_0
+        self._capath_option = CurlOpt.CAPATH
+        self._cainfo_option = CurlOpt.CAINFO
+        self._null_pointer = ffi.NULL
+        self.client = curl_requests.Session(
+            trust_env=False,
+            default_headers=False,
+            discard_cookies=True,
+            http_version=CurlHttpVersion.V2_PRIOR_KNOWLEDGE,
+            curl_options={
+                CurlOpt.HTTP_CONTENT_DECODING: 0,
+                # Requests has already resolved environment proxies/no_proxy.
+                CurlOpt.NOPROXY: "",
+            },
+        )
+        # curl_cffi reads CA environment variables even with trust_env=False.
+        # Only the outer requests session may resolve that environment policy.
+        self.client.verify = True
+
+    def send(self, request, stream=False, timeout=None, verify=True, cert=None, proxies=None):
+        if timeout is not None:
+            values = timeout if isinstance(timeout, tuple) else (timeout,)
+            if (isinstance(timeout, tuple) and len(timeout) != 2) or any(
+                not isinstance(value, (int, float)) for value in values
+            ):
+                raise ValueError("curl timeout must be numeric, a pair of numeric values, or None")
+        # curl_cffi treats string verify values as CA files; requests also accepts
+        # hashed CA directories. Clear the previous directory on every send.
+        self.client.curl_options.pop(self._capath_option, None)
+        self.client.curl_options.pop(self._cainfo_option, None)
+        if isinstance(verify, str) and os.path.isdir(verify):
+            self.client.curl_options[self._capath_option] = verify
+            self.client.curl_options[self._cainfo_option] = self._null_pointer
+            verify = True
+        body = request.body
+        if hasattr(body, "read"):
+            body = body.read()
+        if body is not None and not isinstance(body, (str, bytes, bytearray)):
+            body = b"".join(chunk.encode() if isinstance(chunk, str) else chunk for chunk in body)
+        if isinstance(body, bytearray):
+            body = bytes(body)
+        try:
+            upstream = self.client.request(
+                request.method,
+                request.url,
+                data=body,
+                headers=list(request.headers.items()),
+                # An explicit empty proxy prevents libcurl from reading the
+                # process environment when requests.Session.trust_env is False.
+                proxies={"all": select_proxy(request.url, proxies) or ""},
+                timeout=timeout,
+                verify=verify,
+                cert=cert,
+                allow_redirects=False,
+                default_headers=False,
+                accept_encoding=None,
+                discard_cookies=True,
+                quote=False,
+            )
+        except self._curl_requests.exceptions.RequestException as exc:
+            # curl_cffi adds subclasses such as CertificateVerifyError and
+            # DNSError; preserve their requests-compatible parent category.
+            error_class = exceptions.RequestException
+            transport_errors = {
+                # A partial transfer must not enter private_request's legacy
+                # incomplete-read retry and resubmit a credential-bearing POST.
+                "IncompleteRead": exceptions.ConnectionError,
+                # Curl uses HTTPError for HTTP/2 protocol/stream failures.
+                # HTTP status errors are raised later by requests with a Response.
+                "HTTPError": exceptions.ConnectionError,
+            }
+            for parent in type(exc).__mro__:
+                candidate = transport_errors.get(parent.__name__, getattr(exceptions, parent.__name__, None))
+                if isinstance(candidate, type) and issubclass(candidate, exceptions.RequestException):
+                    error_class = candidate
+                    break
+            raise error_class(f"curl private transport failed ({type(exc).__name__})", request=request) from exc
+
+        if urlsplit(request.url).scheme == "https" and upstream.http_version != self._http2:
+            raise exceptions.ConnectionError("curl private transport did not negotiate HTTP/2", request=request)
+
+        pairs = list(upstream.headers.multi_items())
+        message = Message()
+        for name, value in pairs:
+            message[name] = value
+        raw = HTTPResponse(
+            body=BytesIO(upstream.content),
+            headers=HTTPHeaderDict(pairs),
+            status=upstream.status_code,
+            reason=upstream.reason,
+            version=20,
+            request_method=request.method,
+            preload_content=False,
+            decode_content=False,
+            original_response=SimpleNamespace(msg=message, close=lambda: None, isclosed=lambda: True),
+        )
+        return self.build_response(request, raw)
+
+    def close(self):
+        self.client.close()
+        super().close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ Guides = "https://instagrapi.com/guides/"
 [project.optional-dependencies]
 curl = [
     "curl-adapter>=1.2.1",
+    "curl_cffi>=0.15.0",
 ]
 video = [
     # MoviePy 2.2.1 still declares pillow<12, while instagrapi requires Pillow 12.2.0
@@ -82,9 +83,11 @@ video = [
 ]
 test = [
     "bandit==1.9.4",
+    "cryptography>=46,<47",
     "decorator>=4.0.2,<6.0",
     "imageio>=2.5,<3.0",
     "imageio-ffmpeg>=0.2.0",
+    "h2>=4.3,<5",
     "mike==2.2.0",
     # mike implicitly imports pkg_resources from setuptools — see
     # https://github.com/jimporter/mike/issues/148

--- a/tests/http2_server.py
+++ b/tests/http2_server.py
@@ -1,0 +1,242 @@
+"""Real loopback TLS/H2 fixture; it never opens an upstream connection."""
+
+import base64
+import gzip
+import socket
+import socketserver
+import ssl
+import threading
+import time
+from datetime import datetime, timedelta, timezone
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import ExtendedKeyUsageOID, NameOID
+from h2.config import H2Configuration
+from h2.connection import H2Connection
+from h2.events import DataReceived, RequestReceived, StreamEnded
+
+LAB_HOST = "localhost"
+LAB_JSON = b'{"status":"lab-ok"}'
+
+
+def peek_protocols(sock):
+    """Read ALPN names from the actual ClientHello without consuming it."""
+    header = sock.recv(5, socket.MSG_PEEK | socket.MSG_WAITALL)
+    if len(header) != 5 or header[0] != 22:
+        raise ValueError("Expected a TLS handshake")
+    size = 5 + int.from_bytes(header[3:5], "big")
+    record = sock.recv(size, socket.MSG_PEEK | socket.MSG_WAITALL)
+    if len(record) != size or record[5] != 1:
+        raise ValueError("Expected one complete ClientHello")
+    hello = record[9:]
+    offset = 34
+    offset += 1 + hello[offset]
+    offset += 2 + int.from_bytes(hello[offset : offset + 2], "big")
+    offset += 1 + hello[offset]
+    end = offset + 2 + int.from_bytes(hello[offset : offset + 2], "big")
+    offset += 2
+    protocols = []
+    while offset < end:
+        kind = int.from_bytes(hello[offset : offset + 2], "big")
+        length = int.from_bytes(hello[offset + 2 : offset + 4], "big")
+        value = hello[offset + 4 : offset + 4 + length]
+        offset += 4 + length
+        if kind == 16:
+            index = 2
+            while index < len(value):
+                length = value[index]
+                protocols.append(value[index + 1 : index + 1 + length].decode("ascii"))
+                index += 1 + length
+    if offset != end or end != len(hello):
+        raise ValueError("Malformed ClientHello")
+    return protocols
+
+
+class Handler(socketserver.BaseRequestHandler):
+    def handle(self):
+        raw = self.request
+        raw.settimeout(5)
+        try:
+            offers = peek_protocols(raw)
+            conn = self.server.tls.wrap_socket(raw, server_side=True)
+        except (OSError, ValueError, ssl.SSLError):
+            return
+        with conn:
+            with self.server.lock:
+                self.server.connection_count += 1
+                connection_id = self.server.connection_count
+            h2 = H2Connection(config=H2Configuration(client_side=False, header_encoding="utf-8"))
+            h2.initiate_connection()
+            pending = {}
+            try:
+                conn.sendall(h2.data_to_send())
+                while data := conn.recv(65535):
+                    for event in h2.receive_data(data):
+                        if isinstance(event, RequestReceived):
+                            pending[event.stream_id] = {
+                                "headers": event.headers,
+                                "body": bytearray(),
+                            }
+                        elif isinstance(event, DataReceived):
+                            pending[event.stream_id]["body"].extend(event.data)
+                            h2.acknowledge_received_data(event.flow_controlled_length, event.stream_id)
+                        elif isinstance(event, StreamEnded):
+                            request = pending.pop(event.stream_id)
+                            record = {
+                                "connection_id": connection_id,
+                                "stream_id": event.stream_id,
+                                "alpn_offers": offers,
+                                "negotiated": conn.selected_alpn_protocol(),
+                                "headers": request["headers"],
+                                "body_base64": base64.b64encode(request["body"]).decode(),
+                            }
+                            with self.server.lock:
+                                self.server.records.append(record)
+                            path = dict(request["headers"])[":path"]
+                            if path == "/lab/drop":
+                                return
+                            status, response_headers, body = self.response(path)
+                            declared_length = len(body) + (10 if path.endswith("/lab/partial") else 0)
+                            headers = [
+                                (":status", str(status)),
+                                ("content-length", str(declared_length)),
+                                *response_headers,
+                            ]
+                            if dict(request["headers"])[":method"] == "HEAD":
+                                body = b""
+                            h2.send_headers(event.stream_id, headers, end_stream=not body)
+                            if body:
+                                h2.send_data(event.stream_id, body, end_stream=True)
+                    outgoing = h2.data_to_send()
+                    if outgoing:
+                        conn.sendall(outgoing)
+            except (OSError, ssl.SSLError):
+                return
+
+    @staticmethod
+    def response(path):
+        if path.endswith("/lab/rate-limit"):
+            return 429, [("content-type", "text/plain"), ("retry-after", "7")], b""
+        if path == "/lab/slow":
+            time.sleep(0.25)
+        body = gzip.compress(LAB_JSON, mtime=0)
+        return (
+            200,
+            [
+                ("content-type", "application/json"),
+                ("content-encoding", "gzip"),
+                ("set-cookie", "first_cookie=one; Path=/; Secure"),
+                ("set-cookie", "second_cookie=two; Path=/; Secure"),
+            ],
+            body,
+        )
+
+
+class TCPServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
+    daemon_threads = True
+    block_on_close = False
+    allow_reuse_address = True
+
+
+def _write_certificates(artifacts):
+    root_key = ec.generate_private_key(ec.SECP256R1())
+    root_name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "curl adapter lab CA")])
+    now = datetime.now(timezone.utc)
+    root = (
+        x509.CertificateBuilder()
+        .subject_name(root_name)
+        .issuer_name(root_name)
+        .public_key(root_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - timedelta(minutes=5))
+        .not_valid_after(now + timedelta(days=1))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=0), critical=True)
+        .add_extension(
+            x509.KeyUsage(
+                digital_signature=True,
+                content_commitment=False,
+                key_encipherment=False,
+                data_encipherment=False,
+                key_agreement=False,
+                key_cert_sign=True,
+                crl_sign=True,
+                encipher_only=None,
+                decipher_only=None,
+            ),
+            critical=True,
+        )
+        .sign(root_key, hashes.SHA256())
+    )
+    leaf_key = ec.generate_private_key(ec.SECP256R1())
+    leaf_name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, LAB_HOST)])
+    leaf = (
+        x509.CertificateBuilder()
+        .subject_name(leaf_name)
+        .issuer_name(root_name)
+        .public_key(leaf_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - timedelta(minutes=5))
+        .not_valid_after(now + timedelta(days=1))
+        .add_extension(x509.BasicConstraints(ca=False, path_length=None), critical=True)
+        .add_extension(x509.SubjectAlternativeName([x509.DNSName(LAB_HOST)]), critical=False)
+        .add_extension(x509.ExtendedKeyUsage([ExtendedKeyUsageOID.SERVER_AUTH]), critical=False)
+        .add_extension(
+            x509.KeyUsage(
+                digital_signature=True,
+                content_commitment=False,
+                key_encipherment=False,
+                data_encipherment=False,
+                key_agreement=True,
+                key_cert_sign=False,
+                crl_sign=False,
+                encipher_only=False,
+                decipher_only=False,
+            ),
+            critical=True,
+        )
+        .sign(root_key, hashes.SHA256())
+    )
+    ca_path = artifacts / "lab-ca.pem"
+    cert_path = artifacts / "lab-leaf.pem"
+    key_path = artifacts / "lab-leaf-key.pem"
+    ca_path.write_bytes(root.public_bytes(serialization.Encoding.PEM))
+    cert_path.write_bytes(leaf.public_bytes(serialization.Encoding.PEM))
+    key_path.write_bytes(
+        leaf_key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        )
+    )
+    ca_path.chmod(0o600)
+    cert_path.chmod(0o600)
+    key_path.chmod(0o600)
+    return ca_path, cert_path, key_path
+
+
+class LoopbackServer:
+    def __init__(self, artifacts):
+        ca_path, cert_path, key_path = _write_certificates(artifacts)
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        context.set_alpn_protocols(["h2"])
+        context.load_cert_chain(cert_path, key_path)
+        self.server = TCPServer(("127.0.0.1", 0), Handler)
+        self.server.tls = context
+        self.server.lock = threading.Lock()
+        self.server.connection_count = 0
+        self.server.records = []
+        self.port = self.server.server_address[1]
+        self.records = self.server.records
+        self.ca_path = ca_path
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+
+    def start(self):
+        self.thread.start()
+        return self
+
+    def close(self):
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=5)

--- a/tests/live/test_private_transport.py
+++ b/tests/live/test_private_transport.py
@@ -1,0 +1,174 @@
+"""Explicitly enabled, single-attempt CAA checks on ten fresh test accounts.
+
+Run with INSTAGRAPI_RUN_CAA_LIVE=1 and TEST_ACCOUNTS_URL configured. A private
+INSTAGRAPI_CAA_ACCOUNTS_FILE may instead supply ten freshly assigned records.
+Do not reuse these records for a second run. Credentials and responses are never
+included in pytest failures; successful settings are saved only in the private
+INSTAGRAPI_CAA_LIVE_DIR (or pytest's temporary directory).
+"""
+
+import copy
+import json
+import logging
+import os
+import time
+from pathlib import Path
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+import pytest
+import requests
+
+from instagrapi import Client
+
+pytestmark = pytest.mark.skipif(
+    os.getenv("INSTAGRAPI_RUN_CAA_LIVE") != "1", reason="fresh CAA logins require explicit opt-in"
+)
+
+
+class ProbeStopped(BaseException):
+    """Leave library fallback/retry handlers immediately."""
+
+
+@pytest.fixture(scope="module")
+def fresh_accounts():
+    try:
+        if path := os.getenv("INSTAGRAPI_CAA_ACCOUNTS_FILE"):
+            accounts = json.loads(Path(path).read_text())
+        else:
+            parts = urlsplit(os.environ["TEST_ACCOUNTS_URL"])
+            query = [(k, v) for k, v in parse_qsl(parts.query, keep_blank_values=True) if k != "count"]
+            source = urlunsplit(
+                (parts.scheme, parts.netloc, parts.path, urlencode([*query, ("count", "10")]), parts.fragment)
+            )
+            response = requests.get(source, timeout=(10, 40))
+            response.raise_for_status()
+            accounts = response.json()
+        assert isinstance(accounts, list) and len(accounts) == 10
+        assert len({account["username"].casefold() for account in accounts}) == 10
+        assert all(
+            all(account.get(key) for key in ("username", "password", "user_id", "proxy", "client_settings"))
+            for account in accounts
+        )
+    except Exception as exc:
+        pytest.fail(f"Fresh-account setup failed ({type(exc).__name__})", pytrace=False)
+    return accounts
+
+
+@pytest.fixture(scope="module")
+def private_results(tmp_path_factory):
+    path = os.getenv("INSTAGRAPI_CAA_LIVE_DIR")
+    root = Path(path) if path else tmp_path_factory.mktemp("caa-live")
+    root.mkdir(mode=0o700, parents=True, exist_ok=True)
+    root.chmod(0o700)
+    return root
+
+
+def write_private(path, data):
+    with path.open("w") as stream:
+        path.chmod(0o600)
+        json.dump(data, stream, indent=2)
+
+
+@pytest.mark.parametrize("index", range(10), ids=[f"account-{n:02d}" for n in range(1, 11)])
+def test_caa_login_with_private_curl(fresh_accounts, private_results, index):
+    account = fresh_accounts[index]
+    result_dir = private_results / f"account-{index + 1:02d}"
+    result_dir.mkdir(mode=0o700, exist_ok=True)
+    marker = result_dir / "started.json"
+    try:
+        with marker.open("x") as stream:
+            marker.chmod(0o600)
+            json.dump({"max_password_submissions": 1}, stream)
+    except FileExistsError:
+        pytest.fail(
+            "This account probe was already started; use fresh records and a new results directory", pytrace=False
+        )
+
+    report = {"password_submissions": 0, "responses": [], "session_validated": False}
+    started = time.monotonic()
+    previous_logging = logging.root.manager.disable
+    logging.disable(logging.CRITICAL)
+    client = None
+    try:
+        settings = copy.deepcopy(account["client_settings"])
+        settings.pop("totp_seed", None)
+        settings.update(session_retry_total=0, public_request_retries_count=1, private_transport="curl")
+        client = Client(settings=settings, proxy=account["proxy"])
+        client.username, client.password = account["username"], account["password"]
+        if not client.bloks_versioning_id:
+            pytest.skip("Assigned profile has no known CAA Bloks hash")
+
+        def stop(*args, **kwargs):
+            raise ProbeStopped("Manual account verification required")
+
+        def capture(response, *args, **kwargs):
+            report["responses"].append(response.status_code)
+            if response.status_code == 429:
+                raise ProbeStopped("HTTP 429; no further requests sent")
+            if 300 <= response.status_code < 400:
+                raise ProbeStopped("Unexpected redirect")
+            return response
+
+        client.challenge_code_handler = stop
+        client.change_password_handler = stop
+        client.handle_exception = lambda _client, exc: (_ for _ in ()).throw(exc)
+        for session in (client.private, client.public, client.graphql):
+            session.trust_env = False
+            session.hooks["response"].append(capture)
+            original_send = session.send
+
+            def send(prepared, _send=original_send, **kwargs):
+                target = urlsplit(prepared.url)
+                if target.hostname not in {"i.instagram.com", "b.i.instagram.com", "www.instagram.com"}:
+                    raise ProbeStopped("Unexpected destination")
+                if (
+                    "/challenge/" in target.path
+                    or "/auth_platform/" in target.path
+                    or "/accounts/login/" in target.path
+                ):
+                    raise ProbeStopped("Unexpected login or verification route")
+                if len(report["responses"]) >= 25 or time.monotonic() - started > 180:
+                    raise ProbeStopped("Probe request or time budget reached")
+                if "caa.login.async.send_login_request" in target.path:
+                    if report["password_submissions"]:
+                        raise ProbeStopped("Duplicate password submission blocked")
+                    report["password_submissions"] += 1
+                kwargs.update(timeout=(10, 25), allow_redirects=False)
+                return _send(prepared, **kwargs)
+
+            session.send = send
+
+        client._clear_session_state(
+            clear_authorization_data=True,
+            clear_authorization_header=True,
+            clear_private_cookies=True,
+            clear_public_cookies=True,
+            clear_last_login=True,
+        )
+        assert not client.user_id
+        assert client.bloks_caa_login_prepare(username=client.username)
+        response = client.bloks_caa_login_send_request(client.password, username=client.username, auto_prepare=False)
+        if not client.bloks_apply_login_response(response):
+            if client.bloks_extract_two_step_verification_context(response) or client.bloks_caa_login_needs_two_step(
+                response
+            ):
+                report["verification_required"] = True
+                pytest.skip("CAA reached account verification; session success was not established")
+            pytest.fail("CAA did not return a session", pytrace=False)
+        report["session_validated"] = str(client.account_info().pk) == str(account["user_id"])
+        assert report["session_validated"]
+        assert report["password_submissions"] == 1
+        write_private(result_dir / "settings.private.json", client.get_settings())
+    except ProbeStopped as exc:
+        report["stop_reason"] = str(exc)
+        pytest.fail(str(exc), pytrace=False)
+    except Exception as exc:
+        report["exception"] = type(exc).__name__
+        pytest.fail(f"CAA probe failed ({type(exc).__name__})", pytrace=False)
+    finally:
+        if client:
+            for session in (client.private, client.public, client.graphql):
+                session.close()
+        logging.disable(previous_logging)
+        report["elapsed_seconds"] = round(time.monotonic() - started, 2)
+        write_private(result_dir / "result.sanitized.json", report)

--- a/tests/regression/test_private_transport.py
+++ b/tests/regression/test_private_transport.py
@@ -7,9 +7,10 @@ from requests.adapters import HTTPAdapter
 from instagrapi import Client
 
 
-def test_default_private_transport_does_not_import_optional_dependencies():
-    with mock.patch.dict(sys.modules, {"curl_adapter": None, "curl_cffi": None}):
-        client = Client()
+def test_default_private_transport_does_not_import_optional_dependencies(monkeypatch):
+    monkeypatch.setitem(sys.modules, "curl_adapter", None)
+    monkeypatch.setitem(sys.modules, "curl_cffi", None)
+    client = Client()
 
     assert client.private_transport == "requests"
     assert type(client.private.get_adapter("https://i.instagram.com/")) is HTTPAdapter
@@ -20,10 +21,12 @@ def test_unknown_private_transport_is_rejected():
         Client(private_transport="unknown")
 
 
-def test_missing_curl_extra_has_actionable_error():
-    with mock.patch.dict(sys.modules, {"curl_adapter": None, "curl_cffi": None}):
-        with pytest.raises(RuntimeError, match=r"pip install instagrapi\[curl\]"):
-            Client(private_transport="curl")
+def test_missing_curl_extra_has_actionable_error(monkeypatch):
+    # Keep newly imported application modules cached for later mock targets.
+    monkeypatch.setitem(sys.modules, "curl_adapter", None)
+    monkeypatch.setitem(sys.modules, "curl_cffi", None)
+    with pytest.raises(RuntimeError, match=r"pip install instagrapi\[curl\]"):
+        Client(private_transport="curl")
 
 
 @pytest.fixture

--- a/tests/regression/test_private_transport.py
+++ b/tests/regression/test_private_transport.py
@@ -1,0 +1,98 @@
+import sys
+from unittest import mock
+
+import pytest
+from requests.adapters import HTTPAdapter
+
+from instagrapi import Client
+
+
+def test_default_private_transport_does_not_import_optional_dependencies():
+    with mock.patch.dict(sys.modules, {"curl_adapter": None, "curl_cffi": None}):
+        client = Client()
+
+    assert client.private_transport == "requests"
+    assert type(client.private.get_adapter("https://i.instagram.com/")) is HTTPAdapter
+
+
+def test_unknown_private_transport_is_rejected():
+    with pytest.raises(ValueError, match="private_transport"):
+        Client(private_transport="unknown")
+
+
+def test_missing_curl_extra_has_actionable_error():
+    with mock.patch.dict(sys.modules, {"curl_adapter": None, "curl_cffi": None}):
+        with pytest.raises(RuntimeError, match=r"pip install instagrapi\[curl\]"):
+            Client(private_transport="curl")
+
+
+@pytest.fixture
+def curl_adapter_factory():
+    with mock.patch("instagrapi.transports.create_curl_h2_adapter") as factory:
+        factory.return_value = mock.Mock(spec=HTTPAdapter)
+        yield factory
+
+
+def test_private_curl_keeps_sessions_headers_proxy_and_tls_settings(curl_adapter_factory):
+    client = Client(private_transport="curl", proxy="http://proxy.example:8080", tls_verify="custom-ca.pem")
+
+    assert client.private_transport == "curl"
+    assert client.public_transport == "requests"
+    assert client.private.get_adapter("https://i.instagram.com/") is curl_adapter_factory.return_value
+    curl_adapter_factory.assert_called_once_with()
+    assert type(client.public.get_adapter("https://i.instagram.com/")) is HTTPAdapter
+    assert type(client.graphql.get_adapter("https://i.instagram.com/")) is HTTPAdapter
+    assert client.private.verify == "custom-ca.pem"
+    assert client.private.proxies["https"] == "http://proxy.example:8080"
+    assert client.private.headers["User-Agent"] == client.user_agent
+
+
+def test_private_transport_roundtrip_and_switch_preserve_session(curl_adapter_factory):
+    client = Client(private_transport="curl")
+    adapter = client.private.get_adapter("https://i.instagram.com/")
+    session = client.private
+    session.cookies.set("sessionid", "test-session", domain="i.instagram.com", path="/")
+    session.headers["Authorization"] = "Bearer test-token"
+    settings = client.get_settings()
+
+    assert settings["private_transport"] == "curl"
+    restored = Client(settings=settings)
+    assert restored.private_transport == "curl"
+    assert restored.private.cookies.get("sessionid") == "test-session"
+
+    client.set_retry_config(session_retry_total=0)
+    assert client.private.get_adapter("https://i.instagram.com/") is adapter
+    adapter.close.assert_not_called()
+
+    client.set_retry_config(private_transport="requests")
+    assert client.private is session
+    assert type(session.get_adapter("https://i.instagram.com/")) is HTTPAdapter
+    assert session.cookies.get("sessionid") == "test-session"
+    assert session.headers["Authorization"] == "Bearer test-token"
+    assert client.get_settings()["private_transport"] == "requests"
+    adapter.close.assert_called_once()
+
+
+def test_loading_legacy_settings_keeps_explicit_private_transport(curl_adapter_factory):
+    client = Client(private_transport="curl", settings={"locale": "en_US"})
+    assert client.private_transport == "curl"
+
+
+def test_invalid_transport_update_does_not_replace_adapter(curl_adapter_factory):
+    client = Client(private_transport="curl")
+    adapter = client.private.get_adapter("https://i.instagram.com/")
+    with pytest.raises(ValueError, match="private_transport"):
+        client.set_retry_config(private_transport="unknown")
+    assert client.private.get_adapter("https://i.instagram.com/") is adapter
+    adapter.close.assert_not_called()
+
+
+def test_unavailable_transport_update_keeps_working_configuration():
+    client = Client()
+    adapter = client.private.get_adapter("https://i.instagram.com/")
+    with mock.patch("instagrapi.transports.create_curl_h2_adapter", side_effect=RuntimeError("Unavailable")):
+        with pytest.raises(RuntimeError, match="Unavailable"):
+            client.set_retry_config(private_transport="curl")
+    assert client.private_transport == "requests"
+    assert client.get_settings()["private_transport"] == "requests"
+    assert client.private.get_adapter("https://i.instagram.com/") is adapter

--- a/tests/regression/test_private_transport_wire.py
+++ b/tests/regression/test_private_transport_wire.py
@@ -1,0 +1,266 @@
+"""Exercise the optional transport against a real loopback TLS/HTTP2 server."""
+
+import base64
+import shutil
+import subprocess
+from io import BytesIO
+
+import pytest
+import requests
+from urllib3.util import Timeout
+
+curl_cffi = pytest.importorskip("curl_cffi", reason="install instagrapi[curl] for transport wire tests")
+pytest.importorskip("h2")
+pytest.importorskip("cryptography")
+
+from curl_cffi import CurlHttpVersion, CurlOpt
+
+from instagrapi import Client
+from instagrapi.exceptions import ClientConnectionError, ClientThrottledError
+from tests.http2_server import LAB_HOST, LAB_JSON, LoopbackServer
+
+
+@pytest.fixture
+def lab(tmp_path, monkeypatch):
+    # Curl must never inherit a developer's real proxy during a loopback test.
+    for name in ("http_proxy", "https_proxy", "all_proxy", "no_proxy"):
+        monkeypatch.delenv(name, raising=False)
+        monkeypatch.delenv(name.upper(), raising=False)
+    server = LoopbackServer(tmp_path).start()
+    try:
+        yield server
+    finally:
+        server.close()
+
+
+@pytest.fixture
+def client(lab):
+    client = Client(private_transport="curl", tls_verify=str(lab.ca_path), request_timeout=0)
+    client.private.trust_env = False
+    adapter = client.private.get_adapter("https://localhost/")
+    adapter.client.curl_options[CurlOpt.RESOLVE] = [f"{LAB_HOST}:{lab.port}:127.0.0.1"]
+    try:
+        yield client
+    finally:
+        for session in (client.private, client.public, client.graphql):
+            session.close()
+
+
+def url(lab, path="/lab/ok"):
+    return f"https://{LAB_HOST}:{lab.port}{path}"
+
+
+def test_actual_clienthello_h2_only_and_connection_reuse(client, lab):
+    first = client.private.get(url(lab), timeout=2)
+    second = client.private.get(url(lab), timeout=2)
+
+    assert first.json() == second.json() == {"status": "lab-ok"}
+    assert [r["alpn_offers"] for r in lab.records] == [["h2"], ["h2"]]
+    assert [r["negotiated"] for r in lab.records] == ["h2", "h2"]
+    assert [r["connection_id"] for r in lab.records] == [1, 1]
+    assert [r["stream_id"] for r in lab.records] == [1, 3]
+
+
+def test_mixed_alpn_control_still_negotiates_h2_but_has_different_clienthello(client, lab):
+    adapter = client.private.get_adapter(url(lab))
+    adapter.client.http_version = CurlHttpVersion.V2_0
+    response = client.private.get(url(lab), timeout=2)
+
+    assert response.status_code == 200
+    assert lab.records[0]["negotiated"] == "h2"
+    assert lab.records[0]["alpn_offers"] == ["h2", "http/1.1"]
+
+
+@pytest.mark.parametrize(
+    "body", ["signed_body=SIGNATURE.%7B%22x%22%3A1%7D", b"binary\x00body", BytesIO(b"file\x00body")]
+)
+def test_exact_prepared_body_and_mobile_headers(client, lab, body):
+    expected = body.getvalue() if isinstance(body, BytesIO) else body.encode() if isinstance(body, str) else body
+    request = requests.Request(
+        "POST",
+        url(lab, "/lab/form?encoded=%2F%2B"),
+        data=body,
+        headers={"X-IG-App-ID": "test-app", "Content-Type": "application/octet-stream", "X-Empty": ""},
+    )
+    prepared = client.private.prepare_request(request)
+    original_headers = dict(prepared.headers)
+    response = client.private.send(prepared, verify=str(lab.ca_path), timeout=2)
+
+    assert response.status_code == 200
+    assert dict(prepared.headers) == original_headers
+    observed = lab.records[0]
+    headers = dict(observed["headers"])
+    assert base64.b64decode(observed["body_base64"]) == expected
+    assert headers[":path"] == "/lab/form?encoded=%2F%2B"
+    assert headers["x-ig-app-id"] == "test-app"
+    assert headers["x-empty"] == ""
+    assert headers["content-type"] == "application/octet-stream"
+    assert headers["user-agent"] == client.user_agent
+
+
+def test_gzip_is_decoded_once_and_raw_stream_stays_compressed(client, lab):
+    with client.private.get(url(lab), timeout=2, stream=True) as response:
+        assert response.raw.read(2) == b"\x1f\x8b"
+    with client.private.get(url(lab), timeout=2, stream=True) as response:
+        assert b"".join(response.iter_content(3)) == LAB_JSON
+    assert client.private.get(url(lab), timeout=2).json() == {"status": "lab-ok"}
+
+
+@pytest.mark.parametrize("stream", [False, True])
+def test_head_preserves_content_length_without_expecting_a_body(client, lab, stream):
+    with client.private.head(url(lab), timeout=2, stream=stream) as response:
+        assert response.status_code == 200
+        assert int(response.headers["Content-Length"]) > 0
+        assert b"".join(response.iter_content(3)) == b""
+    assert client.private.get(url(lab), timeout=2).json() == {"status": "lab-ok"}
+    assert [dict(record["headers"])[":method"] for record in lab.records] == ["HEAD", "GET"]
+    assert [record["connection_id"] for record in lab.records] == [1, 1]
+
+
+def test_duplicate_cookies_are_replayed_and_cleared_only_by_requests(client, lab):
+    first = client.private.get(url(lab), timeout=2)
+    assert first.raw.headers.getlist("set-cookie") == [
+        "first_cookie=one; Path=/; Secure",
+        "second_cookie=two; Path=/; Secure",
+    ]
+    assert first.cookies.get_dict() == {"first_cookie": "one", "second_cookie": "two"}
+    client.private.get(url(lab), timeout=2)
+    cookies = dict(lab.records[-1]["headers"])["cookie"]
+    assert set(cookies.split("; ")) == {"first_cookie=one", "second_cookie=two"}
+    client.private.cookies.clear()
+    client.private.get(url(lab), timeout=2)
+    assert "cookie" not in dict(lab.records[-1]["headers"])
+
+
+def test_429_preserves_response_without_automatic_post_retry(client, lab):
+    response = client.private.post(url(lab, "/lab/rate-limit"), data="synthetic_password=test", timeout=2)
+    assert response.status_code == 429
+    assert response.content == b""
+    assert response.headers["Retry-After"] == "7"
+    assert len(lab.records) == 1
+
+
+def test_private_request_maps_429_without_retrying_password(client, lab):
+    with pytest.raises(ClientThrottledError):
+        client.private_request("lab/rate-limit", data={"synthetic_password": "test"}, domain=f"{LAB_HOST}:{lab.port}")
+    assert len(lab.records) == 1
+
+
+def test_connection_drop_maps_error_without_resubmitting_body(client, lab):
+    with pytest.raises(requests.ConnectionError):
+        client.private.post(url(lab, "/lab/drop"), data="synthetic_password=test", timeout=2)
+    assert len(lab.records) == 1
+
+
+def test_truncated_http2_stream_maps_to_requests_connection_error(client, lab):
+    with pytest.raises(requests.ConnectionError):
+        client.private.get(url(lab, "/lab/partial"), timeout=2)
+    assert len(lab.records) == 1
+
+
+def test_private_request_preserves_http2_stream_failure(client, lab):
+    with pytest.raises(ClientConnectionError):
+        client.private_request("lab/partial", domain=f"{LAB_HOST}:{lab.port}")
+    assert len(lab.records) == 1
+
+
+def test_curl_partial_file_does_not_resubmit_password(client, monkeypatch):
+    from curl_cffi.requests.exceptions import IncompleteRead
+
+    submissions = []
+
+    def partial_file(*args, **kwargs):
+        submissions.append(kwargs["data"])
+        raise IncompleteRead("Synthetic partial transfer", code=18)
+
+    adapter = client.private.get_adapter("https://i.instagram.com/")
+    monkeypatch.setattr(adapter.client, "request", partial_file)
+    with pytest.raises(ClientConnectionError):
+        client.private_request("synthetic/partial", data={"synthetic_password": "test"})
+    assert len(submissions) == 1
+
+
+def test_per_request_tls_verification_and_ca_path(client, lab):
+    with pytest.raises(requests.exceptions.SSLError):
+        client.private.get(url(lab), verify=True, timeout=2)
+    assert lab.records == []
+    assert client.private.get(url(lab), verify=str(lab.ca_path), timeout=2).status_code == 200
+
+
+def test_insecure_request_does_not_disable_verification_for_later_requests(client, lab):
+    assert client.private.get(url(lab), verify=False, timeout=2).status_code == 200
+    with pytest.raises(requests.exceptions.SSLError):
+        client.private.get(url(lab), verify=True, timeout=2)
+    assert len(lab.records) == 1
+
+
+def test_per_request_timeout_is_honored(client, lab):
+    with pytest.raises(requests.Timeout):
+        client.private.get(url(lab, "/lab/slow"), timeout=0.05)
+    assert len(lab.records) == 1
+
+
+@pytest.mark.parametrize("timeout", [(None, 0.05), Timeout(connect=0.05, read=0.05)])
+def test_unsupported_timeouts_are_rejected_before_network(client, lab, timeout):
+    with pytest.raises(ValueError, match="numeric"):
+        client.private.get(url(lab, "/lab/slow"), timeout=timeout)
+    assert lab.records == []
+
+
+def test_trust_env_false_does_not_use_curl_environment_proxy(client, lab, monkeypatch):
+    monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:1")
+    monkeypatch.setenv("ALL_PROXY", "http://127.0.0.1:1")
+    assert client.private.get(url(lab), timeout=2).status_code == 200
+
+
+def test_explicit_proxy_overrides_environment_no_proxy(client, lab, monkeypatch):
+    monkeypatch.setenv("NO_PROXY", "*")
+    with pytest.raises(requests.ConnectionError):
+        client.private.get(url(lab), proxies={"https": "http://127.0.0.1:1"}, timeout=0.2)
+    assert lab.records == []
+
+
+def test_session_proxy_change_is_honored(client, lab):
+    assert client.private.get(url(lab), timeout=2).status_code == 200
+    client.set_proxy("http://127.0.0.1:1")
+    with pytest.raises(requests.ConnectionError):
+        client.private.get(url(lab), timeout=0.2)
+    assert len(lab.records) == 1
+
+
+def test_old_libcurl_rejected_before_any_request(monkeypatch):
+    monkeypatch.setattr(curl_cffi, "__curl_version__", "libcurl/8.9.1 OpenSSL")
+    with pytest.raises(RuntimeError, match=r"libcurl.*8\.10"):
+        Client(private_transport="curl")
+
+
+@pytest.mark.parametrize("variable", ["REQUESTS_CA_BUNDLE", "CURL_CA_BUNDLE"])
+def test_requests_controls_whether_to_trust_environment_ca(lab, monkeypatch, variable):
+    monkeypatch.delenv("REQUESTS_CA_BUNDLE", raising=False)
+    monkeypatch.delenv("CURL_CA_BUNDLE", raising=False)
+    monkeypatch.setenv(variable, str(lab.ca_path))
+    client = Client(private_transport="curl")
+    try:
+        client.private.trust_env = False
+        with pytest.raises(requests.exceptions.SSLError):
+            client.private.get(url(lab), timeout=2)
+        assert lab.records == []
+        client.private.trust_env = True
+        assert client.private.get(url(lab), timeout=2).status_code == 200
+    finally:
+        for session in (client.private, client.public, client.graphql):
+            session.close()
+
+
+def test_ca_directory_is_honored_and_does_not_leak_to_later_requests(client, lab, tmp_path):
+    openssl = shutil.which("openssl")
+    if not openssl:
+        pytest.skip("openssl rehash is needed for the CA directory fixture")
+    ca_directory = tmp_path / "ca-directory"
+    ca_directory.mkdir()
+    shutil.copyfile(lab.ca_path, ca_directory / "root.pem")
+    subprocess.run([openssl, "rehash", str(ca_directory)], check=True, capture_output=True)
+    assert client.private.get(url(lab), verify=str(ca_directory), timeout=2).status_code == 200
+    with pytest.raises(requests.exceptions.SSLError):
+        client.private.get(url(lab), verify=True, timeout=2)
+    assert client.private.get(url(lab), verify=str(lab.ca_path), timeout=2).status_code == 200


### PR DESCRIPTION
Related to #2778.

## Summary

Controlled testing reproduced an empty CAA HTTP 429 when TLS advertised both `h2` and `http/1.1`, even when HTTP/2 was negotiated. Offering only `h2` allowed the same controlled CAA flow to complete.

- Add opt-in `Client(private_transport="curl")` using a persistent `curl_cffi` session and h2-only ALPN. The default remains `requests`; transport choice is saved in settings and adjustable through `set_retry_config`.
- Preserve prepared requests, cookies, proxy selection, TLS verification and response decoding. Curl protocol/partial-transfer failures do not trigger the legacy incomplete-read password retry. Valid HEAD responses retain their bodyless semantics.
- Add real TLS/HTTP2 tests, a Python 3.10/3.14 minimum/current curl dependency CI matrix, a guarded live CAA test, and usage documentation.

## Validation

- GitHub CI passed on `57f881a`: all four Python 3.10/3.14 minimum/current curl combinations, Python 3.10–3.14 compatibility checks, dependency checks, lint, Bandit, docs and CodeQL.

- `pytest -q tests/regression`: **832 passed, 3 existing signup-live skips, 37 subtests passed**.
- **35 API/transport tests passed** on macOS with `curl_cffi` 0.16.3 and Linux with `curl_cffi` 0.15.0. Tests inspect actual ClientHello ALPN, HTTP/2 frames and connection reuse, and cover cookies, compression, proxy/TLS changes, timeouts, HEAD and terminal errors.
- The 35 transport tests also pass in a clean Python 3.10 environment; optional-dependency tests preserve application module imports so mocks resolve consistently across Python versions.
- Ruff, formatting, Bandit, strict MkDocs build and pre-commit passed. Independent code review has no open findings.
- Two selected cohorts of ten distinct fresh accounts: **18 immediately validated CAA sessions, 2 verification steps, zero HTTP 429**. These are not a paired transport benchmark.
- Subsequent saved-session checks returned 11 successes, six HTTP 400 responses and one timeout. Captured follow-up evidence for the six affected accounts points to `/accounts/suspended/`; the timeout case later validated successfully. Seven offline response replays confirm the expected `AccountSuspended`/success handling. The causes of the suspensions and original timeout remain unknown. Final transport refinements were checked offline and with saved sessions; the fresh cohorts ran on earlier snapshots.

## Compatibility and limits

Requires `instagrapi[curl]`, `curl_cffi >= 0.15.0` and libcurl >= 8.10. Responses and iterable request bodies are buffered, including `stream=True`. Numeric timeouts use curl's documented transfer budget; unsupported timeout forms fail before sending. The curl adapter does not apply session retry settings. Login routing and challenge handling keep their existing behavior.

This addresses the observed transport behavior, not every cause of #2778, and does not guarantee durable account sessions. No account credentials, proxy addresses, saved sessions or raw responses are included.

## Documentation

README and the public transport guide now distinguish the independently configured public and private curl transports and link to the private HTTP/2 setup, requirements and limitations.
