### PR TITLE
fix: parse current Reels media responses

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -104,6 +104,7 @@ jobs:
             tests/regression/test_media.py::UserMediasGraphQLRegressionTestCase \
             tests/regression/test_user.py::UserMixinRegressionTestCase \
             tests/regression/test_timeline.py::TimelineRegressionTestCase \
+            tests/regression/test_reels_response.py \
             tests/regression/test_story_configure.py::StoryConfigureRegressionTestCase \
             tests/regression/test_video_metadata.py::VideoMetadataRegressionTestCase \
             tests/regression/test_upload.py::UploadRegressionTestCase \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Earlier release notes are available in [GitHub Releases](https://github.com/subzeroid/instagrapi/releases).
 
+## Unreleased
+
+### Fixed
+
+- Reels feed readers now accept media from current `items_with_ads` responses when legacy `items` is empty or absent, avoiding empty results and unnecessary pagination. Existing feed ordering and cursor behavior are preserved.
+
 ## 2.18.19 — 2026-09-09
 
 - Add optional private HTTP/2 transport through `Client(private_transport="curl")` and the `curl` extra. TLS offers only `h2`; private requests retain mobile headers, proxy configuration, cookies and saved device settings. The default transport and login routing remain unchanged. See the [private transport guide](https://github.com/subzeroid/instagrapi/blob/master/docs/usage-guide/interactions.md#private-http2-transport).

--- a/instagrapi/mixins/timeline.py
+++ b/instagrapi/mixins/timeline.py
@@ -104,10 +104,14 @@ class ReelsMixin:
                 self.logger.exception(e)
                 return total_items
 
-            for item in result["items"]:
-                if last_media_pk and last_media_pk == item["media"]["pk"]:
+            items = result.get("items") or result.get("items_with_ads") or []
+            for item in items:
+                media = item.get("media")
+                if not media:
+                    continue
+                if last_media_pk and last_media_pk == media["pk"]:
                     return total_items
-                total_items.append(extract_media_v1(item.get("media")))
+                total_items.append(extract_media_v1(media))
 
             if not result.get("paging_info", {}).get("more_available"):
                 return total_items

--- a/tests/regression/test_reels_response.py
+++ b/tests/regression/test_reels_response.py
@@ -1,0 +1,115 @@
+"""Reels feeds can carry media in items_with_ads instead of legacy items."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from instagrapi import Client
+
+
+def media(pk):
+    pk = str(pk)
+    code = f"code{pk}"
+    return {
+        "media": {
+            "pk": pk,
+            "id": f"{pk}_1",
+            "code": code,
+            "taken_at": 1710000000,
+            "media_type": 2,
+            "caption": {"text": "caption"},
+            "user": {"pk": "1", "username": "example", "profile_pic_url": "https://example.com/profile.jpg"},
+            "like_count": 0,
+            "video_versions": [{"url": "https://example.com/video.mp4", "width": 720, "height": 1280}],
+            "image_versions2": {
+                "candidates": [{"url": "https://example.com/thumbnail.jpg", "width": 720, "height": 1280}]
+            },
+        }
+    }
+
+
+@pytest.mark.parametrize("collection", ["reels", "explore_reels", "friends_reels"])
+@pytest.mark.parametrize("legacy", [{}, {"items": []}])
+def test_modern_reels_returns_first_media_without_requesting_another_page(collection, legacy):
+    client = Client()
+    client.logger = Mock()
+    client.private_request = Mock(
+        side_effect=[
+            {
+                **legacy,
+                "items_with_ads": [media(1), media(2)],
+                "paging_info": {"more_available": True, "max_id": "next-page"},
+            }
+        ]
+    )
+
+    result = client.reels_timeline_media(collection, amount=1)
+
+    assert [item.pk for item in result] == ["1"]
+    assert client.private_request.call_count == 1
+
+
+def test_nonempty_legacy_items_keep_priority_when_both_lists_are_present():
+    client = Client()
+    client.private_request = Mock(
+        return_value={
+            "items": [media(1)],
+            "items_with_ads": [media(2)],
+            "paging_info": {"more_available": False},
+        }
+    )
+
+    assert [item.pk for item in client.explore_reels(amount=10)] == ["1"]
+    assert client.private_request.call_count == 1
+
+
+def test_modern_reels_skips_non_media_wrappers_and_preserves_order():
+    client = Client()
+    client.private_request = Mock(
+        return_value={
+            "items": [],
+            "items_with_ads": [media(1), {"ad": {"id": "synthetic"}}, {"media": None}, media(2)],
+            "paging_info": {"more_available": False},
+        }
+    )
+
+    assert [item.pk for item in client.explore_reels(amount=10)] == ["1", "2"]
+
+
+def test_modern_reels_preserves_server_cursor_between_pages():
+    client = Client()
+    client.private_request = Mock(
+        side_effect=[
+            {"items": [], "items_with_ads": [media(1)], "paging_info": {"more_available": True, "max_id": "next-page"}},
+            {"items_with_ads": [media(2)], "paging_info": {"more_available": False}},
+        ]
+    )
+
+    assert [item.pk for item in client.explore_reels(amount=10)] == ["1", "2"]
+    assert [call.kwargs["params"]["max_id"] for call in client.private_request.call_args_list] == ["", "next-page"]
+
+
+def test_empty_modern_and_legacy_lists_return_no_media():
+    client = Client()
+    client.private_request = Mock(
+        return_value={"items": [], "items_with_ads": [], "paging_info": {"more_available": False}}
+    )
+
+    assert client.explore_reels(amount=10) == []
+    assert client.private_request.call_count == 1
+
+
+def test_modern_reels_preserves_existing_integer_stop_marker():
+    client = Client()
+    stop_item = media(2)
+    stop_item["media"]["pk"] = 2
+    client.private_request = Mock(
+        return_value={
+            "items": [],
+            "items_with_ads": [media(1), stop_item, media(3)],
+            "paging_info": {"more_available": False},
+        }
+    )
+
+    assert [item.pk for item in client.explore_reels(amount=10, last_media_pk=2)] == ["1"]
+    assert client.private_request.call_count == 1


### PR DESCRIPTION
Accept media from current `items_with_ads` responses when legacy `items` is empty or absent. Preserve feed ordering and existing cursor handling.

Mirrored in subzeroid/aiograpi#436. Applies to `reels()`, `explore_reels()` and `friends_reels()`.

Prepared for ordered landing: #2784 → #2785 → #2786 → #2787. This tested branch includes the preceding fixes in that sequence.

Validation:
- Checked independently against released 3.0.1: 896 offline tests passed.
- Checked with the preceding fixes: 896 offline tests passed.
- The final combined release passes 923 offline tests and 18 additional interaction scenarios.
- Original regression fixtures are preserved. Existing login, private transport, upload behavior and full CI matrix are retained.
- Pre-commit, Ruff/format, Bandit, strict docs and wheel/sdist checks pass for the combined release.
- Offline replay of previously captured nonempty responses: 3/7 expected prefixes on the released base, 7/7 with the combined fix.
- External networking disabled in local checks. No new live login or upload performed for this release.
