### PR TITLE
fix: advertise hybrid TLS group in private curl transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Earlier release notes are available in [GitHub Releases](https://github.com/subzeroid/instagrapi/releases).
 
+## Unreleased
+
+- Advertise the hybrid `X25519MLKEM768` TLS group in the optional private curl transport to address connection failures on proxy paths that reject a classical-only ClientHello. Preserve classical groups and h2-only ALPN; this changes TLS reachability, not authentication handling.
+
 ## 2.18.19 — 2026-09-09
 
 - Add optional private HTTP/2 transport through `Client(private_transport="curl")` and the `curl` extra. TLS offers only `h2`; private requests retain mobile headers, proxy configuration, cookies and saved device settings. The default transport and login routing remain unchanged. See the [private transport guide](https://github.com/subzeroid/instagrapi/blob/master/docs/usage-guide/interactions.md#private-http2-transport).

--- a/docs/usage-guide/interactions.md
+++ b/docs/usage-guide/interactions.md
@@ -224,6 +224,8 @@ The transport selection is saved in settings. Restoring settings also restores t
 
 The curl private transport requires `curl_cffi>=0.15.0` and libcurl 8.10 or newer. With older libcurl versions, requesting HTTP/2 can still offer both `h2` and `http/1.1` during TLS negotiation. See the [libcurl HTTP version documentation](https://curl.se/libcurl/c/CURLOPT_HTTP_VERSION.html).
 
+The TLS offer includes the hybrid `X25519MLKEM768` group alongside `X25519`, `P-256` and `P-384` to address connection failures on some proxy paths. Servers without hybrid support can still select a classical group, while ALPN offers only `h2`.
+
 This transport preserves requests' cookie jar, proxy selection, TLS verification, client certificates and redirects. Responses and iterable request bodies are buffered in memory, including when a response is requested with `stream=True`. Response decompression is handled by requests/urllib3. A numeric timeout is curl's total transfer budget; a `(connect, read)` tuple of numbers supplies a connection budget and a total budget of their sum. Use `timeout=None` for no timeout; tuples containing `None` and `urllib3.util.Timeout` objects are rejected before sending a request.
 
 Private curl requests are sent once at the adapter level: `session_retry_total`, `session_retry_backoff_factor` and `session_retry_statuses` do not enable curl retries. HTTP 429 and connection failures reach the existing exception handling. Login routing and challenge handling follow the existing library flow; enabling the transport does not remove account, proxy or verification restrictions.

--- a/instagrapi/transports.py
+++ b/instagrapi/transports.py
@@ -54,6 +54,9 @@ class _CurlH2Adapter(HTTPAdapter):
                 CurlOpt.HTTP_CONTENT_DECODING: 0,
                 # Requests has already resolved environment proxies/no_proxy.
                 CurlOpt.NOPROXY: "",
+                # Some proxy paths reject the default classical-only ClientHello.
+                # Keep classical groups available for peers without hybrid support.
+                CurlOpt.SSL_EC_CURVES: "X25519MLKEM768:X25519:P-256:P-384",
             },
         )
         # curl_cffi reads CA environment variables even with trust_env=False.

--- a/tests/http2_server.py
+++ b/tests/http2_server.py
@@ -21,8 +21,8 @@ LAB_HOST = "localhost"
 LAB_JSON = b'{"status":"lab-ok"}'
 
 
-def peek_protocols(sock):
-    """Read ALPN names from the actual ClientHello without consuming it."""
+def peek_client_hello(sock):
+    """Read ALPN and supported groups from the actual ClientHello."""
     header = sock.recv(5, socket.MSG_PEEK | socket.MSG_WAITALL)
     if len(header) != 5 or header[0] != 22:
         raise ValueError("Expected a TLS handshake")
@@ -38,12 +38,15 @@ def peek_protocols(sock):
     end = offset + 2 + int.from_bytes(hello[offset : offset + 2], "big")
     offset += 2
     protocols = []
+    groups = []
     while offset < end:
         kind = int.from_bytes(hello[offset : offset + 2], "big")
         length = int.from_bytes(hello[offset + 2 : offset + 4], "big")
         value = hello[offset + 4 : offset + 4 + length]
         offset += 4 + length
-        if kind == 16:
+        if kind == 10:
+            groups = [int.from_bytes(value[i : i + 2], "big") for i in range(2, len(value), 2)]
+        elif kind == 16:
             index = 2
             while index < len(value):
                 length = value[index]
@@ -51,7 +54,7 @@ def peek_protocols(sock):
                 index += 1 + length
     if offset != end or end != len(hello):
         raise ValueError("Malformed ClientHello")
-    return protocols
+    return {"alpn_offers": protocols, "supported_groups": groups}
 
 
 class Handler(socketserver.BaseRequestHandler):
@@ -59,7 +62,7 @@ class Handler(socketserver.BaseRequestHandler):
         raw = self.request
         raw.settimeout(5)
         try:
-            offers = peek_protocols(raw)
+            hello = peek_client_hello(raw)
             conn = self.server.tls.wrap_socket(raw, server_side=True)
         except (OSError, ValueError, ssl.SSLError):
             return
@@ -87,7 +90,7 @@ class Handler(socketserver.BaseRequestHandler):
                             record = {
                                 "connection_id": connection_id,
                                 "stream_id": event.stream_id,
-                                "alpn_offers": offers,
+                                **hello,
                                 "negotiated": conn.selected_alpn_protocol(),
                                 "headers": request["headers"],
                                 "body_base64": base64.b64encode(request["body"]).decode(),
@@ -237,6 +240,53 @@ class LoopbackServer:
         return self
 
     def close(self):
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=5)
+
+
+class LoopbackProxy:
+    """CONNECT tunnel restricted to the associated loopback server."""
+
+    def __init__(self, lab):
+        import select
+        from http.server import BaseHTTPRequestHandler
+
+        records = self.records = []
+
+        class ConnectHandler(BaseHTTPRequestHandler):
+            def log_message(self, *args):
+                pass
+
+            def do_CONNECT(self):
+                if self.path != f"{LAB_HOST}:{lab.port}":
+                    self.send_error(403)
+                    return
+                records.append(dict(self.headers))
+                with socket.create_connection(("127.0.0.1", lab.port), timeout=3) as upstream:
+                    self.send_response(200)
+                    self.end_headers()
+                    peers = [self.connection, upstream]
+                    while True:
+                        readable, _, _ = select.select(peers, [], [], 3)
+                        if not readable:
+                            return
+                        for source in readable:
+                            data = source.recv(65536)
+                            if not data:
+                                return
+                            target = upstream if source is self.connection else self.connection
+                            target.sendall(data)
+
+        self.server = TCPServer(("127.0.0.1", 0), ConnectHandler)
+        self.port = self.server.server_address[1]
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+
+    def __enter__(self):
+        self.thread.start()
+        return self
+
+    def __exit__(self, *args):
         self.server.shutdown()
         self.server.server_close()
         self.thread.join(timeout=5)

--- a/tests/regression/test_private_transport_wire.py
+++ b/tests/regression/test_private_transport_wire.py
@@ -264,3 +264,73 @@ def test_ca_directory_is_honored_and_does_not_leak_to_later_requests(client, lab
     with pytest.raises(requests.exceptions.SSLError):
         client.private.get(url(lab), verify=True, timeout=2)
     assert client.private.get(url(lab), verify=str(lab.ca_path), timeout=2).status_code == 200
+
+
+@pytest.fixture
+def hybrid_lab(lab, monkeypatch):
+    from tests import http2_server
+
+    original = http2_server.peek_client_hello
+    hellos = []
+
+    def require_hybrid_group(sock):
+        hello = original(sock)
+        hellos.append(hello)
+        if 4588 not in hello["supported_groups"]:
+            raise ValueError("Peer requires the hybrid group to be advertised")
+        return hello
+
+    monkeypatch.setattr(http2_server, "peek_client_hello", require_hybrid_group)
+    return lab, hellos
+
+
+@pytest.mark.parametrize("proxy_scheme", [None, "http", "socks5h"])
+def test_hybrid_group_reaches_peer_through_proxy(client, hybrid_lab, proxy_scheme):
+    from contextlib import ExitStack
+
+    from tests.http2_server import LoopbackProxy
+    from tests.socks5_proxy import LoopbackSocksProxy
+
+    lab, hellos = hybrid_lab
+    with ExitStack() as stack:
+        if proxy_scheme:
+            proxy_type = LoopbackProxy if proxy_scheme == "http" else LoopbackSocksProxy
+            proxy = stack.enter_context(proxy_type(lab))
+            client.set_proxy(f"{proxy_scheme}://synthetic:password@127.0.0.1:{proxy.port}")
+        first = client.private.post(url(lab), data=b"synthetic-body", timeout=2)
+        second = client.private.get(url(lab), timeout=2)
+        assert first.content == second.content == LAB_JSON
+        assert first.raw.version == second.raw.version == 20
+        headers = dict(lab.records[0]["headers"])
+        assert headers["user-agent"] == client.user_agent
+        assert "proxy-authorization" not in headers
+        assert base64.b64decode(lab.records[0]["body_base64"]) == b"synthetic-body"
+        assert hellos == [{"alpn_offers": ["h2"], "supported_groups": [4588, 29, 23, 24]}]
+        assert [r["connection_id"] for r in lab.records] == [1, 1]
+        if proxy_scheme:
+            assert len(proxy.records) == 1
+        if proxy_scheme == "socks5h":
+            assert proxy.records[0] == {"hostname": "localhost", "port": lab.port, "authenticated": True}
+
+
+def test_classical_group_control_fails_without_resubmitting(client, hybrid_lab):
+    from tests.socks5_proxy import LoopbackSocksProxy
+
+    lab, hellos = hybrid_lab
+    with LoopbackSocksProxy(lab) as proxy:
+        client.set_proxy(f"socks5h://synthetic:password@127.0.0.1:{proxy.port}")
+        adapter = client.private.get_adapter(url(lab))
+        adapter.client.curl_options[CurlOpt.SSL_EC_CURVES] = "X25519:P-256:P-384"
+        with pytest.raises(requests.exceptions.ConnectionError):
+            client.private.post(url(lab), data=b"synthetic-body", timeout=2)
+        assert len(proxy.records) == len(hellos) == 1
+        assert hellos[0]["supported_groups"] == [29, 23, 24]
+        assert not lab.records
+
+
+def test_hybrid_offer_remains_compatible_with_classical_peer(client, lab):
+    # Restrict the server to P-256, which must remain in the client's offer.
+    lab.server.tls.set_ecdh_curve("prime256v1")
+    assert client.private.get(url(lab), timeout=2).content == LAB_JSON
+    assert 23 in lab.records[0]["supported_groups"]
+    assert lab.records[0]["negotiated"] == "h2"

--- a/tests/socks5_proxy.py
+++ b/tests/socks5_proxy.py
@@ -1,0 +1,77 @@
+"""Authenticated SOCKS5 fixture restricted to one loopback TLS server."""
+
+import select
+import socket
+import socketserver
+import threading
+
+
+def read_exact(sock, size):
+    data = bytearray()
+    while len(data) < size:
+        chunk = sock.recv(size - len(data))
+        if not chunk:
+            raise OSError("Incomplete SOCKS5 message")
+        data.extend(chunk)
+    return bytes(data)
+
+
+class LoopbackSocksProxy:
+    def __init__(self, lab):
+        self.records = []
+        records = self.records
+
+        class Handler(socketserver.BaseRequestHandler):
+            def handle(self):
+                conn = self.request
+                conn.settimeout(3)
+                try:
+                    version, count = read_exact(conn, 2)
+                    if version != 5 or 2 not in read_exact(conn, count):
+                        return
+                    conn.sendall(b"\x05\x02")
+                    version, length = read_exact(conn, 2)
+                    username = read_exact(conn, length)
+                    password = read_exact(conn, read_exact(conn, 1)[0])
+                    if version != 1 or username != b"synthetic" or password != b"password":
+                        conn.sendall(b"\x01\x01")
+                        return
+                    conn.sendall(b"\x01\x00")
+                    # Domain-name addressing proves that socks5h defers DNS.
+                    if read_exact(conn, 4) != b"\x05\x01\x00\x03":
+                        return
+                    hostname = read_exact(conn, read_exact(conn, 1)[0]).decode("ascii")
+                    port = int.from_bytes(read_exact(conn, 2), "big")
+                    if hostname != "localhost" or port != lab.port:
+                        return
+                    records.append({"hostname": hostname, "port": port, "authenticated": True})
+                    with socket.create_connection(("127.0.0.1", lab.port), timeout=3) as upstream:
+                        conn.sendall(b"\x05\x00\x00\x01\x7f\x00\x00\x01\x00\x00")
+                        while True:
+                            ready, _, _ = select.select([conn, upstream], [], [], 3)
+                            if not ready:
+                                return
+                            for source in ready:
+                                data = source.recv(65536)
+                                if not data:
+                                    return
+                                (upstream if source is conn else conn).sendall(data)
+                except (OSError, UnicodeError):
+                    return
+
+        class Server(socketserver.ThreadingMixIn, socketserver.TCPServer):
+            daemon_threads = True
+            block_on_close = False
+
+        self.server = Server(("127.0.0.1", 0), Handler)
+        self.port = self.server.server_address[1]
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+
+    def __enter__(self):
+        self.thread.start()
+        return self
+
+    def __exit__(self, *args):
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=5)


### PR DESCRIPTION
The private curl transport can fail before receiving a TLS ServerHello on proxy paths that reject its default classical-only group offer. Advertise `X25519MLKEM768:X25519:P-256:P-384` while retaining h2-only ALPN, certificate verification, mobile request preparation, and existing retry behavior.

Related: subzeroid/aiograpi#441. Thank you to @marnelle1 for the detailed report, control cases, and minimal reproduction.

## Validation

- Five new wire cases: direct, HTTP CONNECT, authenticated SOCKS5h with remote DNS and tunnel reuse, a rejecting-peer classical-only control without resubmission, and compatibility with a classical-only TLS server.
- Before the production change, all three hybrid-required connection cases failed with TLS errors; they pass with the fix.
- Transport suite: **40/40 passed** with curl_cffi **0.15.0 and 0.16.3**.
- Full offline suite: **837 passed, 3 expected skips**. Ruff, pre-commit, Bandit, and package builds passed.
- Independent coverage and adversarial reviews found no issues.

A separate uncredentialed reachability control across ten HTTP CONNECT proxies returned HTTP 405 over HTTP/2 in all 40 requests, both before and after this change. It showed no failing baseline. The reported external SOCKS5 failure has not been independently reproduced; SOCKS5 behavior is covered by the local fixture. This is a TLS reachability change, with no claim of improved authentication outcomes.

Adds an Unreleased changelog entry; no version or default transport changes.

## Documentation

The private transport guide now documents the hybrid TLS group, classical alternatives and preserved h2-only ALPN. Strict MkDocs build passed.
