### PR TITLE
v2.18.20 chore: release private curl TLS fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Earlier release notes are available in [GitHub Releases](https://github.com/subzeroid/instagrapi/releases).
 
-## Unreleased
+## 2.18.20 — 2026-09-12
 
 - Advertise the hybrid `X25519MLKEM768` TLS group in the optional private curl transport to address connection failures on proxy paths that reject a classical-only ClientHello. Preserve classical groups and h2-only ALPN; this changes TLS reachability, not authentication handling.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "instagrapi"
-version = "2.18.19"
+version = "2.18.20"
 authors = [
     {name = "Mark Subzeroid", email = "143403577+subzeroid@users.noreply.github.com"}
 ]


### PR DESCRIPTION
Prepare instagrapi 2.18.20 for PyPI publication with the private curl TLS fix from #2788. This release commit updates the package version and dates the existing changelog entry.

Validation: 837 offline tests passed (3 skipped); wheel and sdist build successfully. Package versions and bundled Python sources were checked against the release tree. Independent scope and release metadata reviews found no issues.
