### PR TITLE
fix: return configured uploads without exposure requests

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -107,6 +107,7 @@ jobs:
             tests/regression/test_story_configure.py::StoryConfigureRegressionTestCase \
             tests/regression/test_video_metadata.py::VideoMetadataRegressionTestCase \
             tests/regression/test_upload.py::UploadRegressionTestCase \
+            tests/regression/test_upload_without_expose.py \
             tests/regression/test_retry.py::RetryRegressionTestCase
 
   test-curl-transport:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Earlier release notes are available in [GitHub Releases](https://github.com/subzeroid/instagrapi/releases).
 
-## Unreleased
+## 3.0.1 — 2026-09-13
 
 - Return configured photos, videos, albums, Reels, IGTV and Stories without a follow-up `qe/expose/` request, preventing an exposure endpoint error from hiding a successful upload (#2790).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Earlier release notes are available in [GitHub Releases](https://github.com/subzeroid/instagrapi/releases).
 
+## Unreleased
+
+- Return configured photos, videos, albums, Reels, IGTV and Stories without a follow-up `qe/expose/` request, preventing an exposure endpoint error from hiding a successful upload (#2790).
+
 ## 2.18.20 — 2026-09-12
 
 - Advertise the hybrid `X25519MLKEM768` TLS group in the optional private curl transport to address connection failures on proxy paths that reject a classical-only ClientHello. Preserve classical groups and h2-only ALPN; this changes TLS reachability, not authentication handling.

--- a/docs/usage-guide/media.md
+++ b/docs/usage-guide/media.md
@@ -360,6 +360,9 @@ If Instagram returns a `Content-Length` header and the downloaded file is shorte
 
 ## Upload media
 
+Photo, video, album, Reel, IGTV and Story upload helpers return the configured publication without a follow-up
+`qe/expose/` request. Errors from the upload or configure request still propagate normally.
+
 Upload medias to your feed. Common arguments:
 
 * `path` - Path to source file

--- a/instagrapi/mixins/album.py
+++ b/instagrapi/mixins/album.py
@@ -264,7 +264,6 @@ class UploadAlbumMixin:
                 raise e
             else:
                 if configured:
-                    self.expose()
                     return self._extract_configured_media_or_raise(
                         configured,
                         configure_exception or AlbumConfigureError,

--- a/instagrapi/mixins/clip.py
+++ b/instagrapi/mixins/clip.py
@@ -1005,7 +1005,6 @@ class UploadClipMixin:
                 raise e
             else:
                 if configured:
-                    self.expose()
                     return self._extract_configured_media_or_raise(
                         configured,
                         ClipConfigureError,

--- a/instagrapi/mixins/igtv.py
+++ b/instagrapi/mixins/igtv.py
@@ -185,7 +185,6 @@ class UploadIGTVMixin:
                 raise e
             else:
                 if configured:
-                    self.expose()
                     return self._extract_configured_media_or_raise(
                         configured,
                         IGTVConfigureError,

--- a/instagrapi/mixins/photo.py
+++ b/instagrapi/mixins/photo.py
@@ -338,7 +338,6 @@ class UploadPhotoMixin:
                 extra_data=extra_data,
             )
             if configured:
-                self.expose()
                 media = self._extract_configured_media_or_recent(
                     configured,
                     PhotoConfigureError,
@@ -633,7 +632,6 @@ class UploadPhotoMixin:
                 extra_data=extra_data,
             )
             if configured:
-                self.expose()
                 return self._extract_configured_story_or_recent(
                     configured,
                     PhotoConfigureStoryError,

--- a/instagrapi/mixins/video.py
+++ b/instagrapi/mixins/video.py
@@ -534,7 +534,6 @@ class UploadVideoMixin:
                 raise e
             else:
                 if configured:
-                    self.expose()
                     return self._extract_configured_media_or_raise(
                         configured,
                         VideoConfigureError,
@@ -745,7 +744,6 @@ class UploadVideoMixin:
                         continue
                     raise e
                 if configured:
-                    self.expose()
                     return self._extract_configured_story_or_recent(
                         configured,
                         VideoConfigureStoryError,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "instagrapi"
-version = "3.0.0"
+version = "3.0.1"
 authors = [
     {name = "Mark Subzeroid", email = "143403577+subzeroid@users.noreply.github.com"}
 ]

--- a/tests/regression/test_upload.py
+++ b/tests/regression/test_upload.py
@@ -1389,15 +1389,10 @@ class UploadRegressionTestCase(unittest.TestCase):
 
         self.assertIn("without media payload and uploaded media was not visible", str(ctx.exception))
 
-    def test_photo_upload_extracts_configure_media_when_expose_overwrites_last_json(self):
+    def test_photo_upload_prefers_configure_media_over_stale_last_json(self):
         client = self.build_client()
         media_payload = self.build_media_payload(media_type=1)
-
-        def expose():
-            client.last_json = {"status": "ok"}
-            return client.last_json
-
-        client.expose = expose
+        client.last_json = {"status": "ok"}
         with mock.patch.object(client, "photo_rupload", return_value=("1", 720, 720)):
             with mock.patch.object(client, "photo_configure", return_value={"status": "ok", "media": media_payload}):
                 with mock.patch("time.sleep"):

--- a/tests/regression/test_upload_without_expose.py
+++ b/tests/regression/test_upload_without_expose.py
@@ -1,0 +1,96 @@
+from copy import deepcopy
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from instagrapi.exceptions import ClientNotFoundError
+from instagrapi.types import Media, Story
+from tests.regression import test_upload as upload_tests
+
+UPLOADS = [
+    ("photo_upload", "media/configure/", 1, Media),
+    ("photo_upload_to_story", "media/configure_to_story/", 1, Story),
+    ("album_upload", "media/configure_sidecar/", 8, Media),
+    ("video_upload", "media/configure/?video=1", 2, Media),
+    ("video_upload_to_story", "media/configure_to_story/?video=1", 2, Story),
+    ("clip_upload", "media/configure_to_clips/?video=1", 2, Media),
+    ("igtv_upload", "media/configure_to_igtv/?video=1", 2, Media),
+]
+
+
+@pytest.fixture
+def upload_client(monkeypatch, tmp_path):
+    helpers = upload_tests.UploadRegressionTestCase()
+    client = helpers.build_client()
+    del client.expose
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"synthetic-video")
+    thumbnail = tmp_path / "thumbnail.jpg"
+    monkeypatch.setattr(client, "_current_media_ids", Mock(return_value=set()))
+    monkeypatch.setattr(client, "_current_story_ids", Mock(return_value=set()))
+    monkeypatch.setattr(client, "photo_rupload", Mock(side_effect=[(str(i), 720, 1280) for i in range(10, 14)]))
+    monkeypatch.setattr(client, "video_rupload", Mock(return_value=("20", 720, 1280, 5, thumbnail)))
+    monkeypatch.setattr(client.private, "get", Mock(return_value=Mock(status_code=200)))
+    monkeypatch.setattr(client.private, "post", Mock(return_value=Mock(status_code=200)))
+    monkeypatch.setattr("instagrapi.mixins.clip.analyze_video", Mock(return_value=(thumbnail, 720, 1280, 5)))
+    monkeypatch.setattr("instagrapi.mixins.igtv.analyze_video", Mock(return_value=(thumbnail, 720, 1280, 5)))
+    monkeypatch.setattr("time.sleep", Mock())
+    yield client, helpers, video
+    client.private.close()
+    client.public.close()
+
+
+def upload(client, method, video):
+    if method == "album_upload":
+        return client.album_upload([Path("first.jpg"), Path("second.jpg")], "caption")
+    if method == "igtv_upload":
+        return client.igtv_upload(video, "title", "caption")
+    path = Path("photo.jpg") if method.startswith("photo_") else video
+    return getattr(client, method)(path, "caption")
+
+
+@pytest.mark.parametrize("method,endpoint,media_type,result_type", UPLOADS, ids=[row[0] for row in UPLOADS])
+def test_upload_returns_configured_result_without_exposure(
+    upload_client, monkeypatch, method, endpoint, media_type, result_type
+):
+    client, helpers, video = upload_client
+    media = helpers.build_media_payload(media_type=media_type)
+    if media_type == 8:
+        media["carousel_media"] = [helpers.build_media_payload(1), helpers.build_media_payload(1)]
+        media["carousel_media"][1].update(pk="2", id="2_1")
+
+    def request(request_endpoint, *args, **kwargs):
+        if request_endpoint == "qe/expose/":
+            raise ClientNotFoundError("Exposure endpoint is unavailable")
+        assert request_endpoint == endpoint
+        client.last_json = {"status": "ok", "media": deepcopy(media)}
+        return client.last_json
+
+    private_request = Mock(side_effect=request)
+    monkeypatch.setattr(client, "private_request", private_request)
+
+    result = upload(client, method, video)
+
+    assert isinstance(result, result_type)
+    assert result.id == "1_1"
+    assert result.media_type == media_type
+    if isinstance(result, Media):
+        assert result.caption_text == "caption"
+    assert [call.args[0] for call in private_request.call_args_list] == [endpoint]
+    if media_type == 8:
+        assert len(result.resources) == 2
+
+
+@pytest.mark.parametrize("method,endpoint,media_type,result_type", UPLOADS, ids=[row[0] for row in UPLOADS])
+def test_upload_preserves_configure_error(upload_client, monkeypatch, method, endpoint, media_type, result_type):
+    client, _, video = upload_client
+    error = ClientNotFoundError("Configure endpoint is unavailable")
+    private_request = Mock(side_effect=error)
+    monkeypatch.setattr(client, "private_request", private_request)
+
+    with pytest.raises(ClientNotFoundError) as caught:
+        upload(client, method, video)
+
+    assert caught.value is error
+    assert [call.args[0] for call in private_request.call_args_list] == [endpoint]


### PR DESCRIPTION
Uploads can raise `ClientNotFoundError` from `qe/expose/` after Instagram has already configured the publication successfully. Remove that automatic follow-up from photo, album, video, Reel, IGTV and both Story upload paths so callers receive the configured `Media` or `Story`.

Upload/configure errors still propagate, and the explicit `client.expose()` API remains available. Update the media guide and release changelog.

Fixes #2790.

Refreshed against the released 3.0.0 base. Retains its CAA login, default private curl/HTTP2 transport, dependencies and complete regression CI matrix. Prepare patch release 3.0.1.

Validation:
- Fresh reproduction on the 3.0.0 base: all seven successful-upload scenarios fail at the post-configure exposure request; the seven configure-error scenarios pass.
- With this fix: 14 focused regressions pass across all seven paths.
- Full offline suite: 885 passed, 3 skipped, 57 subtests passed.
- Pre-commit, Ruff, formatting, Bandit, strict documentation build, wheel and sdist pass.
- Independent specification, coverage and adversarial code reviews found no outstanding issues.
- External networking disabled during local checks. No live upload test run.
