### PR TITLE
feat!: use CAA login and private HTTP/2 by default

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -58,6 +58,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install \
+            "curl_cffi==0.15.0" \
             "requests==2.34.2" \
             "PySocks==1.7.1" \
             "pydantic==2.12.5" \
@@ -68,7 +69,7 @@ jobs:
           python - <<'PY'
           from instagrapi import Client
 
-          Client()
+          assert Client().private_transport == "curl"
           PY
 
   test-compat:
@@ -86,29 +87,50 @@ jobs:
         uses: ./.github/actions/install-dependencies
         with:
           test: "true"
-      - name: Run compatibility smoke tests
+      - name: Run full offline regression suite
+        env:
+          PYTHON_DOTENV_DISABLED: "1"
+          TEST_ACCOUNTS_URL: ""
+        run: pytest -q tests/regression
+
+  default-install:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.10", "3.14"]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Verify a clean standard installation
+        shell: bash
         run: |
-          pytest -sv \
-            tests/regression/test_extractors.py::ExtractorsRegressionTestCase \
-            tests/regression/test_public.py::PublicRegressionTestCase \
-            tests/regression/test_public.py::PrivateGraphQLRequestRegressionTestCase \
-            tests/regression/test_direct.py::DirectMixinRegressionTestCase \
-            tests/regression/test_challenge.py::ChallengeRegressionTestCase \
-            tests/regression/test_comments.py::CommentRepliesRegressionTestCase \
-            tests/regression/test_current_app_profile.py::CurrentAppProfileRegressionTestCase \
-            tests/regression/test_previous_app_profile.py \
-            tests/regression/test_auth_story.py::AuthAndStoryRegressionTestCase \
-            tests/regression/test_attestation.py::CaaLoginRegressionTestCase \
-            tests/regression/test_download.py::DownloadRegressionTestCase \
-            tests/regression/test_notes.py::NoteMixinRegressionTestCase \
-            tests/regression/test_location.py::LocationMixinRegressionTestCase \
-            tests/regression/test_media.py::UserMediasGraphQLRegressionTestCase \
-            tests/regression/test_user.py::UserMixinRegressionTestCase \
-            tests/regression/test_timeline.py::TimelineRegressionTestCase \
-            tests/regression/test_story_configure.py::StoryConfigureRegressionTestCase \
-            tests/regression/test_video_metadata.py::VideoMetadataRegressionTestCase \
-            tests/regression/test_upload.py::UploadRegressionTestCase \
-            tests/regression/test_retry.py::RetryRegressionTestCase
+          python - <<'PY'
+          import os
+          import subprocess
+          import sys
+          from pathlib import Path
+
+          environment = Path(".default-install").resolve()
+          subprocess.run([sys.executable, "-m", "venv", str(environment)], check=True)
+          python = environment / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+          subprocess.run([str(python), "-m", "pip", "install", "."], check=True)
+          subprocess.run([str(python), "-m", "pip", "check"], check=True)
+          code = """
+          import importlib.util
+          from instagrapi import Client
+
+          assert importlib.util.find_spec("h2") is None
+          assert importlib.util.find_spec("curl_adapter") is None
+          client = Client()
+          assert client.private_transport == "curl"
+          assert callable(client.login_legacy)
+          print(type(client.private).__name__, client.private_transport)
+          """
+          subprocess.run([str(python), "-c", code], cwd=environment, check=True)
+          PY
 
   test-curl-transport:
     runs-on: ubuntu-latest
@@ -121,12 +143,12 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install optional transport and wire test dependencies
-        run: python -m pip install ".[curl]" "${{ matrix.curl-cffi }}" pytest "h2>=4.3,<5" "cryptography>=46,<47"
+      - name: Install standard package and wire test dependencies
+        run: python -m pip install . "${{ matrix.curl-cffi }}" pytest "h2>=4.3,<5" "cryptography>=46,<47"
       - name: Verify dependencies and run real TLS/HTTP2 tests
         run: |
           python -c "import curl_cffi, h2, cryptography"
-          pytest -q tests/regression/test_private_transport.py tests/regression/test_private_transport_wire.py
+          pytest -q tests/regression/test_default_transport.py tests/regression/test_private_transport.py tests/regression/test_private_transport_wire.py
 
   build-docs:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,12 @@ Earlier release notes are available in [GitHub Releases](https://github.com/subz
 
 ## Unreleased
 
+- **Breaking:** Make `login()` use CAA directly; retain the previous login flow and arguments as `login_legacy()`. Default login does not automatically fall back to legacy login.
+- Reject CAA login with a clear error before preflight when saved app settings lack the required Bloks hash; document explicit app-profile migration.
+- **Breaking:** Use `curl_cffi` and private HTTP/2 by default and install `curl_cffi` as a runtime dependency. Preserve explicit saved transport choices and the `private_transport="requests"` compatibility option.
+
 - Update the default Android app profile to Instagram `446.0.0.49.77` while retaining the previous `428.0.0.47.67` profile for saved settings and explicit selection.
-- Try the existing CAA login flow when legacy login returns `needs_upgrade`, preserving the original error if no session or supported two-factor flow is available.
+- Try the existing CAA login flow when `login_legacy()` returns `needs_upgrade`, preserving the original error if no session or supported two-factor flow is available.
 
 ## 2.18.20 — 2026-09-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Earlier release notes are available in [GitHub Releases](https://github.com/subzeroid/instagrapi/releases).
 
-## Unreleased
+## 3.0.0 — 2026-09-13
 
 - **Breaking:** Make `login()` use CAA directly; retain the previous login flow and arguments as `login_legacy()`. Default login does not automatically fall back to legacy login.
 - Reject CAA login with a clear error before preflight when saved app settings lack the required Bloks hash; document explicit app-profile migration.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ Support **Python 3.10+**
 pip install instagrapi
 ```
 
-Optional public web TLS impersonation and private HTTP/2 transports are available as an extra:
+Private mobile requests use HTTP/2 through `curl_cffi`, included in the standard installation. `Client()` needs no transport argument, and `login()` uses CAA directly. The previous login remains available as `login_legacy()`. See the [login migration guide](docs/usage-guide/login-migration.md).
+
+Optional public web TLS impersonation is available as an extra:
 
 ```bash
 pip install "instagrapi[curl]"
@@ -44,7 +46,7 @@ cl = Client(public_transport="curl", public_transport_impersonate="chrome136")
 
 See the [public transport guide](docs/usage-guide/public-transport.md) for live comparison results and caveats.
 
-For private mobile API requests, select `Client(private_transport="curl")` separately. See the [private HTTP/2 transport guide](docs/usage-guide/interactions.md#private-http2-transport) for saved-session setup, requirements and limitations.
+Private mobile API requests use curl and HTTP/2 by default. See the [private HTTP/2 transport guide](docs/usage-guide/interactions.md#private-http2-transport) for saved-session setup, requirements and limitations.
 
 TLS certificate verification is enabled by default. For a trusted debugging MITM proxy, prefer `Client(tls_verify="/path/to/proxy-ca.pem")`; use `Client(tls_verify=False)` only for temporary local debugging because it allows session interception.
 

--- a/docs/usage-guide/interactions.md
+++ b/docs/usage-guide/interactions.md
@@ -61,7 +61,7 @@ print(cl.user_info(cl.user_id))
 | session\_retry\_total | Transport-level retry count for `public` and `private` sessions
 | session\_retry\_backoff\_factor | Backoff factor for transport-level retries
 | public\_transport | Public web transport: `requests` by default, or `curl` when `instagrapi[curl]` is installed
-| private\_transport | Private mobile API transport: `requests` by default, or `curl` for HTTP/2 with h2-only ALPN
+| private\_transport | Private mobile API transport: `curl` by default for HTTP/2 with h2-only ALPN; `requests` for compatibility
 | public\_transport\_impersonate | Browser fingerprint used by the optional curl public transport
 | tls\_verify | TLS certificate verification: `True` by default, `False` for temporary trusted MITM debugging, or a CA bundle path
 
@@ -70,12 +70,15 @@ print(cl.user_info(cl.user_id))
 
 | Method                               | Return  | Description
 | ------------------------------------ | ------- | -------------------------------------------------
-| login(username: str, password: str)  | bool    | Login by username and password (get new cookies if it does not exist in settings)
-| login(username: str, password: str, verification\_code: str) | bool | Login by username and password with 2FA verification code (use Google Authenticator or something similar to generate TOTP code, not work with SMS)
+| login(username: str, password: str)  | bool    | CAA login by username and password; validate and reuse a saved session when present
+| login(username: str, password: str, verification\_code: str) | bool | CAA login with a supported TOTP, SMS, backup or profile verification code
+| login\_legacy(username: str, password: str, relogin: bool = False, verification\_code: str = "") | bool | Explicit compatibility entry point for the previous login flow
 | relogin()                            | bool    | Re-login with clean cookies (required cl.username and cl.password)
 | login\_by\_sessionid(sessionid: str) | bool    | Lightweight compatibility login using a session cookie value
 | inject\_sessionid\_to\_public()      | bool    | Inject sessionid from Private Session to Public Session
 | logout()                             | bool    | Logout
+
+`login()` uses CAA directly and does not automatically fall back to `login_legacy()`. Both entry points accept the same arguments. See the [login migration guide](login-migration.md) for compatibility and saved-session behavior.
 
 `login_by_sessionid()` only works when Instagram accepts that `sessionid` for the private mobile API. A browser/web `sessionid` can be rejected with `login_required` or invalidated server-side; for long-lived automation, prefer `login()` once, then `dump_settings()` and reuse the saved settings.
 
@@ -117,7 +120,7 @@ settings = {
     "session_retry_backoff_factor": 2,
     "session_retry_statuses": [429, 500, 502, 503, 504],
     "public_transport": "requests",
-    "private_transport": "requests",
+    "private_transport": "curl",
     "public_transport_impersonate": "chrome136",
     "tls_verify": True,
 }
@@ -215,16 +218,15 @@ See [Public Transport](public-transport.md) for live comparison results and cave
 
 ### Private HTTP/2 transport
 
-Install `instagrapi[curl]` and use `Client(private_transport="curl")` to send private mobile API requests over HTTP/2 with an ALPN offer containing only `h2`. This option also applies to the existing CAA login flow. It preserves the mobile request headers and the account's device settings.
+The standard installation includes `curl_cffi`. `Client()` sends private mobile API requests over HTTP/2 with an ALPN offer containing only `h2`, including CAA login. Mobile request headers and account device settings are preserved.
 
 ```python
 cl = Client(settings=saved_settings, proxy=proxy_url)
-cl.set_retry_config(private_transport="curl")
 cl.login(username, password)
 cl.dump_settings("settings.json")
 ```
 
-The transport selection is saved in settings. Restoring settings also restores their saved transport, taking precedence over the constructor option; call `cl.set_retry_config(private_transport="curl")` afterwards to switch it. Public and GraphQL transports have their own configuration. The default private transport remains `requests`; loading older settings without a transport value preserves an explicitly selected transport.
+Transport selection is saved in settings. An explicit saved choice overrides the constructor; settings without this field preserve the constructor choice, which defaults to `curl`. To migrate settings that explicitly saved `requests`, call `cl.set_retry_config(private_transport="curl")` after loading them, then save again. `Client(private_transport="requests")` selects the previous private transport. Public and GraphQL transports have their own configuration.
 
 The curl private transport requires `curl_cffi>=0.15.0` and libcurl 8.10 or newer. With older libcurl versions, requesting HTTP/2 can still offer both `h2` and `http/1.1` during TLS negotiation. See the [libcurl HTTP version documentation](https://curl.se/libcurl/c/CURLOPT_HTTP_VERSION.html).
 
@@ -232,7 +234,7 @@ The TLS offer includes the hybrid `X25519MLKEM768` group alongside `X25519`, `P-
 
 This transport preserves requests' cookie jar, proxy selection, TLS verification, client certificates and redirects. Responses and iterable request bodies are buffered in memory, including when a response is requested with `stream=True`. Response decompression is handled by requests/urllib3. A numeric timeout is curl's total transfer budget; a `(connect, read)` tuple of numbers supplies a connection budget and a total budget of their sum. Use `timeout=None` for no timeout; tuples containing `None` and `urllib3.util.Timeout` objects are rejected before sending a request.
 
-Private curl requests are sent once at the adapter level: `session_retry_total`, `session_retry_backoff_factor` and `session_retry_statuses` do not enable curl retries. HTTP 429 and connection failures reach the existing exception handling. Login routing and challenge handling follow the existing library flow; enabling the transport does not remove account, proxy or verification restrictions.
+Private curl requests are sent once at the adapter level: `session_retry_total`, `session_retry_backoff_factor` and `session_retry_statuses` do not enable curl retries. HTTP 429 and connection failures reach the existing exception handling. `login()` uses CAA; `login_legacy()` explicitly selects the previous login flow. Transport selection does not remove account, proxy or verification restrictions.
 
 ### Private mobile headers
 

--- a/docs/usage-guide/interactions.md
+++ b/docs/usage-guide/interactions.md
@@ -58,8 +58,8 @@ print(cl.user_info(cl.user_id))
 | request\_timeout    | Timeout in seconds between requests (1 second by default)
 | public\_request\_retries\_count | Default retry count for `public_request()`
 | public\_request\_retries\_timeout | Delay between `public_request()` retries
-| session\_retry\_total | Transport-level retry count for `public` and `private` sessions
-| session\_retry\_backoff\_factor | Backoff factor for transport-level retries
+| session\_retry\_total | Adapter retry count for Requests transports; private curl does not use this setting
+| session\_retry\_backoff\_factor | Backoff factor for Requests adapter retries; private curl does not use this setting
 | public\_transport | Public web transport: `requests` by default, or `curl` when `instagrapi[curl]` is installed
 | private\_transport | Private mobile API transport: `curl` by default for HTTP/2 with h2-only ALPN; `requests` for compatibility
 | public\_transport\_impersonate | Browser fingerprint used by the optional curl public transport
@@ -136,7 +136,7 @@ Store and manage uuids, device configuration, user agent, authorization data (ak
 | ------------------------------ | ------- | ------------------------------------------------------------------
 | get\_settings()                | dict    | Return settings dict
 | set\_settings(settings: dict)  | bool    | Set session settings
-| load\_settings(path: Path)     | dict    | Load session settings from file
+| load\_settings(path: Path, override\_app\_version: bool = False) | dict | Load session settings; optionally update the app version, version code and Bloks hash
 | dump\_settings(path: Path)     | bool    | Serialize and save session settings to file
 
 In order for Instagram [to trust you more](https://github.com/subzeroid/instagrapi/discussions/220), use one stable device profile and one stable IP (or subnet) per account whenever possible:
@@ -199,7 +199,7 @@ cl.set_retry_config(
 )
 ```
 
-For the default Requests transport, `session_retry_total` controls adapter-level attempts for `session_retry_statuses`. After those attempts are exhausted, instagrapi receives the final response and raises its normal typed exception, such as `ClientThrottledError` for HTTP 429. When adapter retries are enabled, `public_request()` does not start a second retry package for the same configured status; when `session_retry_total<=0`, the existing `public_request_retries_count` loop remains active. Connection, TLS, DNS, and timeout exhaustion remain transport errors because there is no final HTTP response to map. The optional curl public transport uses its own adapter and is unaffected by these urllib3 settings.
+For the Requests transport (`public_transport="requests"` by default, or explicitly `private_transport="requests"`), `session_retry_total` controls adapter-level attempts for `session_retry_statuses`. After those attempts are exhausted, instagrapi receives the final response and raises its normal typed exception, such as `ClientThrottledError` for HTTP 429. When adapter retries are enabled, `public_request()` does not start a second retry package for the same configured status; when `session_retry_total<=0`, the existing `public_request_retries_count` loop remains active. Connection, TLS, DNS, and timeout exhaustion remain transport errors because there is no final HTTP response to map. The optional curl public transport uses its own adapter and is unaffected by these urllib3 settings.
 
 For public web endpoints that are sensitive to browser TLS fingerprints, install the optional curl transport:
 

--- a/docs/usage-guide/login-migration.md
+++ b/docs/usage-guide/login-migration.md
@@ -1,6 +1,6 @@
 # CAA login migration
 
-The upcoming major version changes the default login flow and private transport. These changes are currently unreleased.
+Version 3.0.0 changes the default login flow and private transport. This guide explains how to migrate existing applications and saved settings.
 
 ## Default usage
 

--- a/docs/usage-guide/login-migration.md
+++ b/docs/usage-guide/login-migration.md
@@ -1,0 +1,90 @@
+# CAA login migration
+
+The upcoming major version changes the default login flow and private transport. These changes are currently unreleased.
+
+## Default usage
+
+Install the package normally; `curl_cffi` is a required dependency:
+
+```bash
+pip install instagrapi
+```
+
+The application code stays simple:
+
+```python
+from instagrapi import Client
+
+cl = Client()
+cl.login(USERNAME, PASSWORD)
+```
+
+`login()` uses CAA directly. It does not try `accounts/login/` first and does not automatically fall back to that endpoint after a CAA failure. All private mobile API requests use curl with HTTP/2 by default. Public web and GraphQL transports retain their separate configuration.
+
+## Keep the previous login flow
+
+The previous method is now named `login_legacy()`. Its arguments and existing fallback behavior are preserved:
+
+```python
+cl = Client()
+cl.login_legacy(USERNAME, PASSWORD, verification_code="123456")
+```
+
+Login flow and transport are independent choices. To explicitly use the previous Requests private transport as well:
+
+```python
+cl = Client(private_transport="requests")
+cl.login_legacy(USERNAME, PASSWORD)
+```
+
+An explicit legacy login may still invoke its existing CAA fallback. There is no automatic fallback in the opposite direction. `relogin()` uses the new default CAA flow; use `login_legacy(relogin=True)` to explicitly repeat the previous flow.
+
+## Reuse saved sessions
+
+Both entry points validate an existing session before using the supplied credentials. If Instagram rejects that session with `LoginRequired`, each repeats its own login flow after clearing the expired authorization state.
+
+```python
+cl = Client()
+cl.load_settings("session.json")
+cl.login(USERNAME, PASSWORD)
+cl.dump_settings("session.json")
+```
+
+Settings with an explicit `private_transport` keep that choice, even when it differs from the constructor. Settings without that field keep the selected constructor transport, which now defaults to `curl`.
+
+To migrate settings that explicitly saved `requests`:
+
+```python
+cl.load_settings("session.json")
+cl.set_retry_config(private_transport="curl")
+cl.login(USERNAME, PASSWORD)
+cl.dump_settings("session.json")
+```
+
+This transport change does not replace the saved device profile, proxy, cookies or authorization data. Keep the account's existing proxy configuration when restoring its session.
+
+## Older app profiles without a Bloks hash
+
+CAA needs a Bloks hash matching the configured app version. Saved settings for an older unsupported version may lack this hash. If the session cannot be reused, `login()` raises `ClientError` before starting CAA requests and explains how to update the profile.
+
+Use the supported profile explicitly when migrating those settings:
+
+```python
+cl = Client()
+cl.load_settings("session.json", override_app_version=True)
+cl.set_retry_config(private_transport="curl")  # migrate an explicit saved requests choice
+cl.login(USERNAME, PASSWORD)
+cl.dump_settings("session.json")
+```
+
+`override_app_version=True` updates the app version, version code and Bloks hash. It retains hardware settings and device identifiers. Keep using the account's existing proxy. Alternatively, provide the correct Bloks hash for the original profile or explicitly use `login_legacy()`.
+
+## Verification and failures
+
+Continue to pass `verification_code` for supported two-factor challenges. The CAA profile-code flow also supports `challenge_code_handler`; see [TOTP](totp.md). Native CAA exceptions propagate. A response without a session or a supported verification context raises `ClientError` with the CAA failure reason. Curl does not automatically retry a failed password POST.
+
+## Installation requirements
+
+Private HTTP/2 requires `curl_cffi>=0.15.0` and libcurl 8.10 or newer. `curl_cffi` normally supplies libcurl in its wheels; a system `curl` executable and the Python `h2` package are not required for this transport. A compatible wheel or a supported native build is required for your platform. Android/Termux has not been verified.
+
+The optional `instagrapi[curl]` extra remains available for public web browser impersonation through `curl-adapter`. It is not required for private HTTP/2. See [private HTTP/2 transport](interactions.md#private-http2-transport) for TLS, proxy and timeout behavior.

--- a/docs/usage-guide/public-transport.md
+++ b/docs/usage-guide/public-transport.md
@@ -24,8 +24,8 @@ from instagrapi import Client
 cl = Client(public_transport="curl", public_transport_impersonate="chrome136")
 ```
 
-`public_transport` configures the public web session. Private mobile API requests use `requests` by default and can
-separately opt into [private HTTP/2 transport](interactions.md#private-http2-transport) with `private_transport="curl"`.
+`public_transport` configures the public web session. Private mobile API requests
+use [private HTTP/2 transport](interactions.md#private-http2-transport) by default.
 
 ## Live Comparison
 

--- a/docs/usage-guide/totp.md
+++ b/docs/usage-guide/totp.md
@@ -38,13 +38,9 @@ Notes:
 
 ## Bloks two-factor flow
 
-Some accounts are moved by Instagram to a newer CAA/Bloks two-factor flow. In that case the legacy `accounts/two_factor_login/` endpoint can reject a valid code with `Invalid Parameters`.
+`cl.login(..., verification_code="123456")` uses CAA directly, including device registration and server-issued preflight state. A successful embedded session is applied automatically. The CAA profile-code flow uses the supplied `verification_code` or `challenge_code_handler`. When Instagram returns `two_step_verification_context`, the existing Bloks verification helpers handle the code; a missing code raises `TwoFactorRequired`.
 
-`Client.login(..., verification_code="123456")` still uses the legacy mobile endpoint first. If Instagram returns a `two_step_verification_context`, instagrapi automatically retries through the Bloks two-factor flow. If the legacy endpoint instead returns `BadPassword` without that context, instagrapi retries the current Android CAA login sequence, including its device registration and server-issued preflight state. A successful embedded session is applied automatically. When Instagram opens the CAA profile-code screen, instagrapi uses the supplied `verification_code` or `challenge_code_handler` and applies the terminal session response.
-
-A legacy login response with `error_type="needs_upgrade"` also uses the existing CAA fallback and forwards
-`verification_code`. Other `UnknownError` responses propagate directly. If CAA provides neither a session nor a
-supported two-factor flow, `login()` preserves the original `needs_upgrade` error.
+The previous login flow is available explicitly as `cl.login_legacy(...)`, with the same arguments and its existing CAA/Bloks fallbacks. Default `login()` never invokes that legacy flow automatically. See the [login migration guide](login-migration.md).
 
 8-digit backup codes can be passed through the same `verification_code` parameter:
 
@@ -93,4 +89,4 @@ result = cl.bloks_two_step_verification_verify_code(context, "12345678", challen
 
 `bloks_extract_login_response(...)` returns decoded `login_response`, response `headers`, cookie values, raw cookie header text, and the raw embedded object when Instagram returns a successful Bloks login payload. It returns `{}` when the response is an intermediate UI state or an error. `bloks_apply_login_response(...)` can then copy the returned authorization data and cookies into the current client session.
 
-The separate account-recovery UI used by some accounts is not automated. If current CAA login does not return a session or a supported profile-code challenge, `login()` preserves the original `BadPassword`. That response can still mean a wrong password or Instagram account-risk handling, so inspect proxy/IP and device consistency before retrying repeatedly.
+The separate account-recovery UI used by some accounts is not automated. Native CAA exceptions propagate from `login()`. If CAA returns neither a session nor a supported verification context, `login()` raises `ClientError` with the CAA failure reason. The explicit `login_legacy()` entry point preserves its previous fallback error behavior.

--- a/instagrapi/mixins/auth.py
+++ b/instagrapi/mixins/auth.py
@@ -718,8 +718,96 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
         relogin: bool = False,
         verification_code: str = "",
     ) -> bool:
+        """Log in using the current Android CAA flow.
+
+        Parameters
+        ----------
+        username: str
+            Instagram Username. Uses stored credentials when omitted.
+        password: str
+            Instagram Password. Uses stored credentials when omitted.
+        relogin: bool
+            Clear the current session before logging in, default False.
+        verification_code: str
+            Two-factor or profile verification code.
+
+        Returns
+        -------
+        bool
+            True after successful login or validation of an existing session.
+
+        Notes
+        -----
+        Existing sessions are validated before reuse. Rejected sessions are
+        cleared and refreshed through CAA. CAA errors propagate directly;
+        use ``login_legacy`` to select the legacy accounts login flow.
         """
-        Login
+        if username and password:
+            self.username = username
+            self.password = password
+        if self.username is None or self.password is None:
+            raise BadCredentials("Both username and password must be provided.")
+        if isinstance(self.username, str):
+            self.username = self.username.strip()
+
+        if relogin:
+            self._clear_session_state(
+                clear_authorization_data=True,
+                clear_authorization_header=True,
+                clear_private_cookies=True,
+                clear_public_cookies=True,
+            )
+            if self.relogin_attempt > 1:
+                raise ReloginAttemptExceeded()
+            self.relogin_attempt += 1
+        if self.user_id and not relogin:
+            try:
+                self.account_info()
+            except LoginRequired:
+                return self.login(relogin=True, verification_code=verification_code)
+            return True
+
+        if not self.bloks_versioning_id:
+            raise ClientError(
+                "CAA login requires bloks_versioning_id for the saved app profile. "
+                "Load settings with override_app_version=True to use the supported app profile, "
+                "or provide the matching Bloks hash."
+            )
+        outcome = self.bloks_caa_login(verification_code=verification_code)
+        logged = bool(outcome.get("logged_in"))
+        if not logged:
+            context = self._extract_two_step_verification_context(outcome)
+            if context:
+                exc = TwoFactorRequired(
+                    "Instagram returned a Bloks two-factor context from the CAA login flow; "
+                    "provide verification_code for login",
+                    response=self.last_response,
+                    **self._exception_context(outcome),
+                )
+                if not verification_code.strip():
+                    raise exc
+                logged = self._login_with_bloks_two_factor(verification_code, outcome, exc)
+            if not logged:
+                raise ClientError(
+                    str(outcome.get("reason") or "CAA login did not return a session"),
+                    response=self.last_response,
+                    **self._exception_context(outcome),
+                )
+
+        self.login_flow()
+        self.last_login = time.time()
+        self.relogin_attempt = 0
+        return True
+
+    def login_legacy(
+        self,
+        username: Union[str, None] = None,
+        password: Union[str, None] = None,
+        relogin: bool = False,
+        verification_code: str = "",
+    ) -> bool:
+        """
+        Login using the legacy accounts endpoint and its existing fallbacks.
 
         Parameters
         ----------
@@ -768,7 +856,7 @@ class LoginMixin(PreLoginFlowMixin, PostLoginFlowMixin):
             try:
                 self.account_info()
             except LoginRequired:
-                return self.login(relogin=True, verification_code=verification_code)
+                return self.login_legacy(relogin=True, verification_code=verification_code)
             return True
         try:
             self.pre_login_flow()

--- a/instagrapi/mixins/private.py
+++ b/instagrapi/mixins/private.py
@@ -135,7 +135,7 @@ class PrivateRequestMixin:
     session_retry_total = 3
     session_retry_backoff_factor = 2
     session_retry_statuses = [429, 500, 502, 503, 504]
-    private_transport = "requests"
+    private_transport = "curl"
     domain = config.API_DOMAIN
     last_response = None
     last_json = {}

--- a/instagrapi/transports.py
+++ b/instagrapi/transports.py
@@ -1,4 +1,4 @@
-"""Optional transports for the requests sessions used by Client."""
+"""Private HTTP/2 transport for the requests sessions used by Client."""
 
 import os
 import re
@@ -32,7 +32,7 @@ class _CurlH2Adapter(HTTPAdapter):
             from curl_cffi import requests as curl_requests
         except ImportError as exc:
             raise RuntimeError(
-                "curl private transport requires the optional curl extra: pip install instagrapi[curl]"
+                "curl private transport requires curl_cffi>=0.15.0; reinstall instagrapi with its dependencies"
             ) from exc
 
         version = re.search(r"libcurl/(\d+)\.(\d+)\.(\d+)", curl_cffi.__curl_version__)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,7 @@ nav:
     - Examples: usage-guide/examples.md
     - Fundamentals: usage-guide/fundamentals.md
     - Interactions: usage-guide/interactions.md
+    - Login Migration: usage-guide/login-migration.md
     - TOTP: usage-guide/totp.md
     - Types: usage-guide/types.md
     - Challenge Resolver: usage-guide/challenge_resolver.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ keywords = [
     "instagram-note",
 ]
 dependencies = [
+    "curl_cffi>=0.15.0",
     "requests>=2.34.2,<3",
     "PySocks>=1.7.1,<2",
     "pydantic==2.12.5; sys_platform == 'android'",
@@ -69,7 +70,6 @@ Guides = "https://instagrapi.com/guides/"
 [project.optional-dependencies]
 curl = [
     "curl-adapter>=1.2.1",
-    "curl_cffi>=0.15.0",
 ]
 video = [
     # MoviePy 2.2.1 still declares pillow<12, while instagrapi requires Pillow 12.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "instagrapi"
-version = "2.18.20"
+version = "3.0.0"
 authors = [
     {name = "Mark Subzeroid", email = "143403577+subzeroid@users.noreply.github.com"}
 ]

--- a/tests/regression/test_auth_story.py
+++ b/tests/regression/test_auth_story.py
@@ -9,7 +9,7 @@ class AuthAndStoryRegressionTestCase(unittest.TestCase):
         with self.assertRaises(BadCredentials):
             client.login()
 
-    def test_login_continues_after_pre_login_throttling(self):
+    def test_login_legacy_continues_after_pre_login_throttling(self):
         client = Client()
         client.username = "example"
         client.password = "password"
@@ -21,14 +21,14 @@ class AuthAndStoryRegressionTestCase(unittest.TestCase):
         client.login_flow = Mock()
         client.password_encrypt = Mock(return_value="enc-password")
 
-        result = client.login()
+        result = client.login_legacy()
 
         self.assertTrue(result)
         client.pre_login_flow.assert_called_once_with()
         client.private_request.assert_called_once()
         client.login_flow.assert_called_once_with()
 
-    def test_login_continues_after_client_throttled_error(self):
+    def test_login_legacy_continues_after_client_throttled_error(self):
         client = Client()
         client.username = "example"
         client.password = "password"
@@ -40,7 +40,7 @@ class AuthAndStoryRegressionTestCase(unittest.TestCase):
         client.login_flow = Mock()
         client.password_encrypt = Mock(return_value="enc-password")
 
-        result = client.login()
+        result = client.login_legacy()
 
         self.assertTrue(result)
         client.pre_login_flow.assert_called_once_with()
@@ -78,7 +78,7 @@ class AuthAndStoryRegressionTestCase(unittest.TestCase):
         client.pre_login_flow.assert_not_called()
         client.private_request.assert_not_called()
 
-    def test_login_refreshes_session_rejected_during_validation(self):
+    def test_login_legacy_refreshes_session_rejected_during_validation(self):
         client = Client()
         client.authorization_data = {"ds_user_id": "123", "sessionid": "stale"}
         client.private.cookies.set("sessionid", "stale")
@@ -92,7 +92,7 @@ class AuthAndStoryRegressionTestCase(unittest.TestCase):
         client.private_request = Mock(return_value=True)
         client.login_flow = Mock()
 
-        result = client.login("example", "password")
+        result = client.login_legacy("example", "password")
 
         self.assertTrue(result)
         client.account_info.assert_called_once_with()
@@ -117,7 +117,7 @@ class AuthAndStoryRegressionTestCase(unittest.TestCase):
         client.pre_login_flow.assert_not_called()
         client.private_request.assert_not_called()
 
-    def test_login_uses_stored_username_when_called_without_args(self):
+    def test_login_legacy_uses_stored_username_when_called_without_args(self):
         client = Client()
         client.username = "example"
         client.password = "password"
@@ -129,13 +129,13 @@ class AuthAndStoryRegressionTestCase(unittest.TestCase):
         client.login_flow = Mock()
         client.password_encrypt = Mock(return_value="enc-password")
 
-        result = client.login()
+        result = client.login_legacy()
 
         self.assertTrue(result)
         payload = client.private_request.call_args.args[1]
         self.assertEqual(payload["username"], "example")
 
-    def test_login_strips_outer_username_whitespace(self):
+    def test_login_legacy_strips_outer_username_whitespace(self):
         client = Client()
         client.authorization_data = {}
         client.last_response = Mock(headers={"ig-set-authorization": "Bearer token"})
@@ -145,14 +145,14 @@ class AuthAndStoryRegressionTestCase(unittest.TestCase):
         client.login_flow = Mock()
         client.password_encrypt = Mock(return_value="enc-password")
 
-        result = client.login(" example ", "password")
+        result = client.login_legacy(" example ", "password")
 
         self.assertTrue(result)
         payload = client.private_request.call_args.args[1]
         self.assertEqual(payload["username"], "example")
         self.assertEqual(client.username, "example")
 
-    def test_login_two_factor_requires_verification_code(self):
+    def test_login_legacy_two_factor_requires_verification_code(self):
         client = Client()
         client.username = "example"
         client.password = "password"
@@ -161,11 +161,11 @@ class AuthAndStoryRegressionTestCase(unittest.TestCase):
         client.password_encrypt = Mock(return_value="enc-password")
 
         with self.assertRaises(TwoFactorRequired) as cm:
-            client.login()
+            client.login_legacy()
 
         self.assertIn("you did not provide verification_code", str(cm.exception))
 
-    def test_login_two_factor_uses_verification_code_flow(self):
+    def test_login_legacy_two_factor_uses_verification_code_flow(self):
         client = Client()
         client.username = "example"
         client.password = "password"
@@ -187,7 +187,7 @@ class AuthAndStoryRegressionTestCase(unittest.TestCase):
             ]
         )
 
-        result = client.login(verification_code="123456")
+        result = client.login_legacy(verification_code="123456")
 
         self.assertTrue(result)
         self.assertEqual(client.private_request.call_count, 2)
@@ -200,7 +200,7 @@ class AuthAndStoryRegressionTestCase(unittest.TestCase):
         self.assertEqual(second_call.args[1]["username"], "example")
         client.login_flow.assert_called_once_with()
 
-    def test_login_two_factor_invalid_parameters_raises_clear_bloks_hint(self):
+    def test_login_legacy_two_factor_invalid_parameters_raises_clear_bloks_hint(self):
         client = Client()
         client.username = "example"
         client.password = "password"
@@ -220,12 +220,12 @@ class AuthAndStoryRegressionTestCase(unittest.TestCase):
         )
 
         with self.assertRaises(TwoFactorRequired) as cm:
-            client.login(verification_code="123456")
+            client.login_legacy(verification_code="123456")
 
         self.assertIn("Bloks-based two-factor verification flow", str(cm.exception))
         self.assertEqual(client.private_request.call_count, 2)
 
-    def test_login_two_factor_invalid_parameters_falls_back_to_bloks_when_context_available(self):
+    def test_login_legacy_two_factor_invalid_parameters_falls_back_to_bloks_when_context_available(self):
         client = Client()
         client.username = "example"
         client.password = "password"
@@ -257,7 +257,7 @@ class AuthAndStoryRegressionTestCase(unittest.TestCase):
         client.bloks_two_step_verification_verify_code = Mock(return_value={"layout": {}})
         client.bloks_apply_login_response = Mock(return_value=True)
 
-        result = client.login(verification_code="123456")
+        result = client.login_legacy(verification_code="123456")
 
         self.assertTrue(result)
         self.assertEqual(client.private_request.call_count, 2)
@@ -272,7 +272,7 @@ class AuthAndStoryRegressionTestCase(unittest.TestCase):
         client.bloks_apply_login_response.assert_called_once_with({"layout": {}})
         client.login_flow.assert_called_once_with()
 
-    def test_login_two_factor_backup_code_with_context_uses_bloks_without_legacy_two_factor_request(self):
+    def test_login_legacy_two_factor_backup_code_with_context_uses_bloks_without_legacy_two_factor_request(self):
         client = Client()
         client.username = "example"
         client.password = "password"
@@ -300,7 +300,7 @@ class AuthAndStoryRegressionTestCase(unittest.TestCase):
         client.bloks_two_step_verification_verify_code = Mock(return_value={"layout": {}})
         client.bloks_apply_login_response = Mock(return_value=True)
 
-        result = client.login(verification_code="1234 5678")
+        result = client.login_legacy(verification_code="1234 5678")
 
         self.assertTrue(result)
         self.assertEqual(client.private_request.call_count, 1)
@@ -316,7 +316,7 @@ class AuthAndStoryRegressionTestCase(unittest.TestCase):
         )
         client.login_flow.assert_called_once_with()
 
-    def test_login_two_factor_invalid_parameters_without_context_keeps_clear_error(self):
+    def test_login_legacy_two_factor_invalid_parameters_without_context_keeps_clear_error(self):
         client = Client()
         client.username = "example"
         client.password = "password"
@@ -337,12 +337,12 @@ class AuthAndStoryRegressionTestCase(unittest.TestCase):
         client.bloks_two_step_verification_verify_code = Mock()
 
         with self.assertRaises(TwoFactorRequired) as cm:
-            client.login(verification_code="123456")
+            client.login_legacy(verification_code="123456")
 
         self.assertIn("two_step_verification_context", str(cm.exception))
         client.bloks_two_step_verification_verify_code.assert_not_called()
 
-    def test_login_bad_password_with_bloks_context_and_code_falls_back_to_bloks(self):
+    def test_login_legacy_bad_password_with_bloks_context_and_code_falls_back_to_bloks(self):
         client = Client()
         client.username = "example"
         client.password = "password"
@@ -362,7 +362,7 @@ class AuthAndStoryRegressionTestCase(unittest.TestCase):
         client.bloks_two_step_verification_verify_code = Mock(return_value={"layout": {}})
         client.bloks_apply_login_response = Mock(return_value=True)
 
-        result = client.login(verification_code="654321")
+        result = client.login_legacy(verification_code="654321")
 
         self.assertTrue(result)
         client.bloks_two_step_verification_select_method.assert_called_once_with("context-1", selected_method="sms")
@@ -373,7 +373,7 @@ class AuthAndStoryRegressionTestCase(unittest.TestCase):
         )
         client.login_flow.assert_called_once_with()
 
-    def test_login_bad_password_without_context_tries_current_caa_flow(self):
+    def test_login_legacy_bad_password_without_context_tries_current_caa_flow(self):
         client = Client()
         client.username = "example"
         client.password = "password"
@@ -385,13 +385,13 @@ class AuthAndStoryRegressionTestCase(unittest.TestCase):
         client.private_request = Mock(side_effect=BadPassword("Bad Password", response=Mock(status_code=400)))
         client.bloks_caa_login = Mock(return_value={"logged_in": True})
 
-        result = client.login(verification_code="654321")
+        result = client.login_legacy(verification_code="654321")
 
         self.assertTrue(result)
         client.bloks_caa_login.assert_called_once_with(verification_code="654321")
         client.login_flow.assert_called_once_with()
 
-    def test_login_bad_password_recovery_response_tries_current_caa_flow_without_code(self):
+    def test_login_legacy_bad_password_recovery_response_tries_current_caa_flow_without_code(self):
         client = Client()
         client.username = "example"
         client.password = "password"
@@ -407,13 +407,13 @@ class AuthAndStoryRegressionTestCase(unittest.TestCase):
         client.private_request = Mock(side_effect=BadPassword("Bad Password", response=Mock(status_code=400)))
         client.bloks_caa_login = Mock(return_value={"logged_in": True})
 
-        result = client.login()
+        result = client.login_legacy()
 
         self.assertTrue(result)
         client.bloks_caa_login.assert_called_once_with(verification_code="")
         client.login_flow.assert_called_once_with()
 
-    def test_login_with_eight_digit_backup_code_selects_backup_code_bloks_challenge(self):
+    def test_login_legacy_with_eight_digit_backup_code_selects_backup_code_bloks_challenge(self):
         client = Client()
         client.username = "example"
         client.password = "password"
@@ -434,7 +434,7 @@ class AuthAndStoryRegressionTestCase(unittest.TestCase):
         client.bloks_two_step_verification_verify_code = Mock(return_value={"layout": {}})
         client.bloks_apply_login_response = Mock(return_value=True)
 
-        result = client.login(verification_code="1234 5678")
+        result = client.login_legacy(verification_code="1234 5678")
 
         self.assertTrue(result)
         client.bloks_two_step_verification_select_method.assert_called_once_with(
@@ -449,7 +449,7 @@ class AuthAndStoryRegressionTestCase(unittest.TestCase):
         )
         client.login_flow.assert_called_once_with()
 
-    def test_login_bad_password_without_context_preserves_original_error_when_caa_has_no_session(self):
+    def test_login_legacy_bad_password_without_context_preserves_original_error_when_caa_has_no_session(self):
         client = Client()
         client.username = "example"
         client.password = "password"
@@ -463,11 +463,11 @@ class AuthAndStoryRegressionTestCase(unittest.TestCase):
         )
 
         with self.assertRaises(BadPassword):
-            client.login(verification_code="654321")
+            client.login_legacy(verification_code="654321")
 
         client.bloks_caa_login.assert_called_once_with(verification_code="654321")
 
-    def test_login_bad_password_without_context_preserves_original_error_when_caa_is_unavailable(self):
+    def test_login_legacy_bad_password_without_context_preserves_original_error_when_caa_is_unavailable(self):
         client = Client()
         client.username = "example"
         client.password = "password"
@@ -489,11 +489,11 @@ class AuthAndStoryRegressionTestCase(unittest.TestCase):
         client.bloks_caa_login = Mock(side_effect=caa_error)
 
         with self.assertRaises(BadPassword):
-            client.login(verification_code="654321")
+            client.login_legacy(verification_code="654321")
 
         client.bloks_caa_login.assert_called_once_with(verification_code="654321")
 
-    def test_login_needs_upgrade_tries_current_caa_flow(self):
+    def test_login_legacy_needs_upgrade_tries_current_caa_flow(self):
         client = Client()
         client.username = "example"
         client.password = "password"
@@ -514,13 +514,13 @@ class AuthAndStoryRegressionTestCase(unittest.TestCase):
         )
         client.bloks_caa_login = Mock(return_value={"logged_in": True})
 
-        result = client.login(verification_code="654321")
+        result = client.login_legacy(verification_code="654321")
 
         self.assertTrue(result)
         client.bloks_caa_login.assert_called_once_with(verification_code="654321")
         client.login_flow.assert_called_once_with()
 
-    def test_login_needs_upgrade_preserves_original_error_when_caa_has_no_session(self):
+    def test_login_legacy_needs_upgrade_preserves_original_error_when_caa_has_no_session(self):
         client = Client()
         client.username = "example"
         client.password = "password"
@@ -541,7 +541,7 @@ class AuthAndStoryRegressionTestCase(unittest.TestCase):
         client.bloks_caa_login = Mock(return_value={"logged_in": False, "two_step_verification_context": ""})
 
         with self.assertRaises(UnknownError):
-            client.login(verification_code="654321")
+            client.login_legacy(verification_code="654321")
 
         client.bloks_caa_login.assert_called_once_with(verification_code="654321")
 
@@ -699,7 +699,7 @@ class AuthAndStoryRegressionTestCase(unittest.TestCase):
         with self.assertRaises(AssertionError):
             client.login_by_sessionid("abcdefghijklmnopqrstuvwxyz123456")
 
-    def test_login_resets_relogin_attempt_after_success(self):
+    def test_login_legacy_resets_relogin_attempt_after_success(self):
         client = Client()
         client.username = "example"
         client.password = "password"
@@ -712,7 +712,7 @@ class AuthAndStoryRegressionTestCase(unittest.TestCase):
         client.login_flow = Mock()
         client.password_encrypt = Mock(return_value="enc-password")
 
-        result = client.login(relogin=True)
+        result = client.login_legacy(relogin=True)
 
         self.assertTrue(result)
         self.assertEqual(client.relogin_attempt, 0)

--- a/tests/regression/test_default_transport.py
+++ b/tests/regression/test_default_transport.py
@@ -1,0 +1,29 @@
+import pytest
+
+from instagrapi import Client
+from instagrapi.transports import _CurlH2Adapter
+
+
+@pytest.mark.parametrize(
+    "kwargs, expected",
+    [
+        ({}, "curl"),
+        ({"settings": {"locale": "en_US"}}, "curl"),
+        ({"private_transport": "requests"}, "requests"),
+        ({"settings": {"locale": "en_US"}, "private_transport": "requests"}, "requests"),
+        ({"settings": {"private_transport": "requests"}, "private_transport": "curl"}, "requests"),
+        ({"settings": {"private_transport": "curl"}, "private_transport": "requests"}, "curl"),
+    ],
+)
+def test_private_transport_default_and_saved_precedence(kwargs, expected):
+    client = Client(**kwargs)
+    try:
+        assert client.private_transport == expected
+        assert (isinstance(client.private.get_adapter("https://i.instagram.com/"), _CurlH2Adapter)) is (
+            expected == "curl"
+        )
+        assert client.get_settings()["private_transport"] == expected
+        assert client.public_transport == "requests"
+    finally:
+        for session in (client.private, client.public, client.graphql):
+            session.close()

--- a/tests/regression/test_login_default.py
+++ b/tests/regression/test_login_default.py
@@ -1,0 +1,398 @@
+import inspect
+import unittest
+from copy import deepcopy
+from unittest.mock import Mock, patch
+
+from instagrapi import Client, config
+from instagrapi.exceptions import (
+    BadCredentials,
+    BadPassword,
+    ChallengeError,
+    ClientError,
+    ClientNotFoundError,
+    LoginRequired,
+    PleaseWaitFewMinutes,
+    ReloginAttemptExceeded,
+    TwoFactorRequired,
+    UnknownError,
+)
+
+
+class LoginDefaultRegressionTestCase(unittest.TestCase):
+    def setUp(self):
+        self.client = Client(private_transport="requests")
+        self.client.pre_login_flow = Mock(side_effect=AssertionError("Unexpected legacy preflight"))
+        self.client.password_encrypt = Mock(side_effect=AssertionError("Unexpected legacy encryption"))
+        self.client.private_request = Mock(side_effect=AssertionError("Unexpected legacy request"))
+        self.client.login_flow = Mock()
+        self.client.bloks_caa_login = Mock(side_effect=self.caa_success)
+
+    def caa_success(self, **kwargs):
+        self.client.authorization_data = {"ds_user_id": "123", "sessionid": "fresh"}
+        return self.caa_outcome(logged_in=True)
+
+    def caa_outcome(self, **updates):
+        outcome = {
+            "logged_in": False,
+            "two_step_verification_context": "",
+            "result": {},
+            "two_step": {},
+            "reason": "CAA login did not return a session",
+        }
+        outcome.update(updates)
+        return outcome
+
+    def legacy_success(self):
+        self.client.pre_login_flow = Mock(return_value=True)
+        self.client.password_encrypt = Mock(return_value="encrypted")
+        self.client.private_request = Mock(return_value=True)
+        self.client.last_response = Mock(headers={"ig-set-authorization": "Bearer fresh"})
+        self.client.parse_authorization = Mock(return_value={"ds_user_id": "123", "sessionid": "fresh"})
+        self.client.bloks_caa_login = Mock(side_effect=AssertionError("Unexpected CAA fallback"))
+
+    def saved_session(self):
+        self.client.authorization_data = {"ds_user_id": "123", "sessionid": "stale"}
+        self.client.private.cookies.set("sessionid", "stale")
+        self.client.public.cookies.set("sessionid", "public-stale")
+        self.client.private.headers["Authorization"] = "Bearer stale"
+
+    def assert_session_cleared(self):
+        self.assertNotIn("Authorization", self.client.private.headers)
+        self.assertEqual(self.client.private.cookies.get_dict(), {})
+        self.assertEqual(self.client.public.cookies.get_dict(), {})
+
+    def test_login_uses_caa_directly_and_finalizes_success(self):
+        self.client.relogin_attempt = 1
+        with patch("instagrapi.mixins.auth.time.time", return_value=1234567890.0):
+            result = self.client.login(" example ", "password", False, "654321")
+
+        self.assertTrue(result)
+        self.assertEqual(self.client.username, "example")
+        self.assertEqual(self.client.password, "password")
+        self.assertEqual(self.client.authorization_data["sessionid"], "fresh")
+        self.client.bloks_caa_login.assert_called_once_with(verification_code="654321")
+        self.client.pre_login_flow.assert_not_called()
+        self.client.password_encrypt.assert_not_called()
+        self.client.private_request.assert_not_called()
+        self.client.login_flow.assert_called_once_with()
+        self.assertEqual(self.client.last_login, 1234567890.0)
+        self.assertEqual(self.client.relogin_attempt, 0)
+
+    def test_login_uses_stored_credentials(self):
+        self.client.username = " example "
+        self.client.password = "password"
+
+        self.assertTrue(self.client.login())
+
+        self.assertEqual(self.client.username, "example")
+        self.client.bloks_caa_login.assert_called_once_with(verification_code="")
+
+    def test_login_and_legacy_keep_the_same_call_signature(self):
+        self.assertTrue(hasattr(Client, "login_legacy"))
+        self.assertEqual(inspect.signature(Client.login), inspect.signature(Client.login_legacy))
+
+    def test_both_entrypoints_require_credentials_before_network_calls(self):
+        self.assertTrue(hasattr(Client, "login_legacy"))
+        for entrypoint in ("login", "login_legacy"):
+            with self.subTest(entrypoint=entrypoint):
+                with self.assertRaises(BadCredentials):
+                    getattr(self.client, entrypoint)()
+        self.client.bloks_caa_login.assert_not_called()
+        self.client.pre_login_flow.assert_not_called()
+
+    def test_legacy_login_keeps_accounts_endpoint_and_preflight(self):
+        self.assertTrue(hasattr(Client, "login_legacy"))
+        self.legacy_success()
+
+        self.assertTrue(self.client.login_legacy(" example ", "password", False, "654321"))
+
+        self.client.pre_login_flow.assert_called_once_with()
+        self.client.password_encrypt.assert_called_once_with("password")
+        self.client.private_request.assert_called_once()
+        self.assertEqual(self.client.private_request.call_args.args[0], "accounts/login/")
+        self.assertEqual(self.client.private_request.call_args.args[1]["username"], "example")
+        self.client.bloks_caa_login.assert_not_called()
+        self.client.login_flow.assert_called_once_with()
+
+    def test_both_entrypoints_validate_saved_sessions_without_submitting_credentials(self):
+        self.assertTrue(hasattr(Client, "login_legacy"))
+        self.saved_session()
+        self.client.account_info = Mock(return_value=object())
+        self.client.last_login = 123.0
+        for entrypoint in ("login", "login_legacy"):
+            with self.subTest(entrypoint=entrypoint):
+                self.assertTrue(getattr(self.client, entrypoint)("example", "password"))
+        self.assertEqual(self.client.account_info.call_count, 2)
+        self.client.bloks_caa_login.assert_not_called()
+        self.client.pre_login_flow.assert_not_called()
+        self.client.login_flow.assert_not_called()
+        self.assertEqual(self.client.last_login, 123.0)
+
+    def test_expired_session_is_cleared_and_refreshed_with_caa(self):
+        self.saved_session()
+        self.client.account_info = Mock(side_effect=LoginRequired())
+
+        self.assertTrue(self.client.login("example", "password", verification_code="654321"))
+
+        self.client.account_info.assert_called_once_with()
+        self.client.bloks_caa_login.assert_called_once_with(verification_code="654321")
+        self.assert_session_cleared()
+        self.assertEqual(self.client.authorization_data["sessionid"], "fresh")
+        self.assertEqual(self.client.relogin_attempt, 0)
+
+    def test_expired_legacy_session_stays_on_legacy_entrypoint(self):
+        self.assertTrue(hasattr(Client, "login_legacy"))
+        self.saved_session()
+        self.legacy_success()
+        self.client.account_info = Mock(side_effect=LoginRequired())
+
+        self.assertTrue(self.client.login_legacy("example", "password", verification_code="654321"))
+
+        self.client.account_info.assert_called_once_with()
+        self.client.pre_login_flow.assert_called_once_with()
+        self.assertEqual(self.client.private_request.call_args.args[0], "accounts/login/")
+        self.client.bloks_caa_login.assert_not_called()
+        self.assert_session_cleared()
+        self.assertEqual(self.client.authorization_data["sessionid"], "fresh")
+
+    def test_relogin_clears_session_without_validation(self):
+        self.saved_session()
+        self.client.account_info = Mock(side_effect=AssertionError("Unexpected session validation"))
+
+        self.assertTrue(self.client.login("example", "password", relogin=True))
+
+        self.assert_session_cleared()
+        self.client.account_info.assert_not_called()
+        self.client.bloks_caa_login.assert_called_once_with(verification_code="")
+        self.assertEqual(self.client.relogin_attempt, 0)
+
+    def test_failed_relogin_attempts_are_bounded_for_both_entrypoints(self):
+        self.assertTrue(hasattr(Client, "login_legacy"))
+        for entrypoint in ("login", "login_legacy"):
+            with self.subTest(entrypoint=entrypoint):
+                self.client.relogin_attempt = 0
+                self.client.pre_login_flow = Mock(return_value=True)
+                self.client.password_encrypt = Mock(return_value="encrypted")
+                self.client.private_request = Mock(side_effect=PleaseWaitFewMinutes("rate limit"))
+                self.client.bloks_caa_login = Mock(side_effect=PleaseWaitFewMinutes("rate limit"))
+                for attempt in (1, 2):
+                    self.saved_session()
+                    with self.assertRaises(PleaseWaitFewMinutes):
+                        getattr(self.client, entrypoint)("example", "password", relogin=True)
+                    self.assertEqual(self.client.relogin_attempt, attempt)
+                    self.assert_session_cleared()
+                    self.assertEqual(self.client.authorization_data, {})
+                self.saved_session()
+                with self.assertRaises(ReloginAttemptExceeded):
+                    getattr(self.client, entrypoint)(relogin=True)
+                self.assert_session_cleared()
+                self.assertEqual(self.client.authorization_data, {})
+                request = self.client.bloks_caa_login if entrypoint == "login" else self.client.private_request
+                self.assertEqual(request.call_count, 2)
+
+    def test_default_propagates_native_caa_errors_without_retry_or_finalization(self):
+        for exception_type in (
+            BadPassword,
+            ClientNotFoundError,
+            UnknownError,
+            ChallengeError,
+            TwoFactorRequired,
+            LoginRequired,
+            PleaseWaitFewMinutes,
+            ClientError,
+        ):
+            with self.subTest(exception_type=exception_type):
+                error = exception_type("native CAA failure")
+                self.client.bloks_caa_login = Mock(side_effect=error)
+                with self.assertRaises(exception_type) as caught:
+                    self.client.login("example", "password", verification_code="654321")
+                self.assertIs(caught.exception, error)
+                self.client.bloks_caa_login.assert_called_once_with(verification_code="654321")
+        self.client.pre_login_flow.assert_not_called()
+        self.client.private_request.assert_not_called()
+        self.client.login_flow.assert_not_called()
+        self.assertIsNone(self.client.last_login)
+
+    def test_session_validation_failure_is_not_retried_as_login(self):
+        self.saved_session()
+        error = PleaseWaitFewMinutes("validation rate limit")
+        self.client.account_info = Mock(side_effect=error)
+
+        with self.assertRaises(PleaseWaitFewMinutes) as caught:
+            self.client.login("example", "password")
+
+        self.assertIs(caught.exception, error)
+        self.client.bloks_caa_login.assert_not_called()
+        self.assertEqual(self.client.authorization_data["sessionid"], "stale")
+
+    def test_caa_outcome_without_session_raises_its_reason(self):
+        self.client.bloks_caa_login = Mock(return_value=self.caa_outcome(reason="CAA preflight was incomplete"))
+
+        with self.assertRaisesRegex(ClientError, "CAA preflight was incomplete"):
+            self.client.login("example", "password")
+
+        self.client.bloks_caa_login.assert_called_once_with(verification_code="")
+        self.client.login_flow.assert_not_called()
+        self.client.pre_login_flow.assert_not_called()
+
+    def test_caa_outcome_without_reason_has_clear_error(self):
+        self.client.bloks_caa_login = Mock(return_value=self.caa_outcome(reason=""))
+
+        with self.assertRaisesRegex(ClientError, "CAA login did not return a session"):
+            self.client.login("example", "password")
+
+    def test_caa_two_factor_context_requires_a_code(self):
+        self.client.bloks_caa_login = Mock(return_value=self.caa_outcome(two_step_verification_context="context-1"))
+
+        with self.assertRaisesRegex(TwoFactorRequired, "verification_code"):
+            self.client.login("example", "password", verification_code=" ")
+
+        self.client.bloks_caa_login.assert_called_once_with(verification_code=" ")
+        self.client.login_flow.assert_not_called()
+        self.client.private_request.assert_not_called()
+
+    def test_caa_context_selects_totp_sms_and_normalized_backup_codes(self):
+        for code, challenge, flags, expected_code in (
+            ("654321", "totp", {"totp_two_factor_on": True}, "654321"),
+            ("654321", "sms", {"sms_two_factor_on": True}, "654321"),
+            ("1234 5678", "backup_codes", {"totp_two_factor_on": True}, "12345678"),
+        ):
+            with self.subTest(challenge=challenge):
+                self.client.bloks_caa_login = Mock(
+                    return_value=self.caa_outcome(
+                        two_step_verification_context="context-1",
+                        result={"two_factor_info": flags},
+                    )
+                )
+                self.client.bloks_two_step_verification_entrypoint = Mock(return_value={"status": "ok"})
+                self.client.bloks_two_step_verification_method_picker = Mock(return_value={"status": "ok"})
+                self.client.bloks_two_step_verification_select_method = Mock(return_value={"status": "ok"})
+                self.client.bloks_two_step_verification_enter_backup_code = Mock(return_value={"status": "ok"})
+                self.client.bloks_two_step_verification_verify_code = Mock(return_value={"layout": {}})
+                self.client.bloks_apply_login_response = Mock(return_value=True)
+
+                self.assertTrue(self.client.login("example", "password", verification_code=code))
+
+                self.client.bloks_caa_login.assert_called_once_with(verification_code=code)
+                self.client.bloks_two_step_verification_entrypoint.assert_called_once_with("context-1")
+                self.client.bloks_two_step_verification_select_method.assert_called_once_with(
+                    "context-1", selected_method=challenge
+                )
+                self.client.bloks_two_step_verification_verify_code.assert_called_once_with(
+                    "context-1", expected_code, challenge=challenge
+                )
+                self.client.bloks_apply_login_response.assert_called_once_with({"layout": {}})
+                if challenge == "backup_codes":
+                    self.client.bloks_two_step_verification_enter_backup_code.assert_called_once_with("context-1")
+                else:
+                    self.client.bloks_two_step_verification_enter_backup_code.assert_not_called()
+        self.assertEqual(self.client.login_flow.call_count, 3)
+        self.client.private_request.assert_not_called()
+
+    def test_context_verification_error_is_not_retried(self):
+        self.client.bloks_caa_login = Mock(return_value=self.caa_outcome(two_step_verification_context="context-1"))
+        error = TwoFactorRequired("Incorrect verification code")
+        self.client.bloks_two_step_verification_entrypoint = Mock(side_effect=error)
+
+        with self.assertRaises(TwoFactorRequired) as caught:
+            self.client.login("example", "password", verification_code="654321")
+
+        self.assertIs(caught.exception, error)
+        self.client.bloks_caa_login.assert_called_once_with(verification_code="654321")
+        self.client.login_flow.assert_not_called()
+
+    def test_completed_caa_verification_does_not_submit_code_again(self):
+        self.client.bloks_caa_login = Mock(return_value=self.caa_outcome(logged_in=True, two_step={"logged_in": True}))
+        self.client.bloks_two_step_verification_entrypoint = Mock(
+            side_effect=AssertionError("Unexpected repeated two-factor verification")
+        )
+
+        self.assertTrue(self.client.login("example", "password", verification_code="654321"))
+
+        self.client.bloks_caa_login.assert_called_once_with(verification_code="654321")
+        self.client.bloks_two_step_verification_entrypoint.assert_not_called()
+        self.client.login_flow.assert_called_once_with()
+
+    def old_app_settings(self):
+        settings = deepcopy(self.client.get_settings())
+        settings["device_settings"].update({"app_version": "410.0.0.0.1", "version_code": "123456789"})
+        settings["device_settings"].pop("bloks_versioning_id", None)
+        return settings
+
+    def test_missing_saved_app_hash_stops_caa_before_preflight(self):
+        settings = self.old_app_settings()
+        original_settings = deepcopy(settings)
+        for mode in ("fresh", "relogin", "expired"):
+            with self.subTest(mode=mode):
+                self.client = Client(settings=settings, private_transport="requests")
+                self.assertIsNone(self.client.bloks_versioning_id)
+                self.client.bloks_caa_login = Mock(wraps=self.client.bloks_caa_login)
+                self.client.bloks_caa_login_prepare = Mock(side_effect=AssertionError("Unexpected CAA preflight"))
+                self.client.pre_login_flow = Mock(side_effect=AssertionError("Unexpected legacy preflight"))
+                self.client.login_legacy = Mock(side_effect=AssertionError("Unexpected legacy fallback"))
+                self.client.private_request = Mock(side_effect=AssertionError("Unexpected private request"))
+                if mode != "fresh":
+                    self.saved_session()
+                if mode == "expired":
+                    self.client.account_info = Mock(side_effect=LoginRequired())
+
+                with self.assertRaisesRegex(ClientError, "CAA login requires bloks_versioning_id") as caught:
+                    self.client.login("example", "password", relogin=mode == "relogin")
+
+                self.assertIs(type(caught.exception), ClientError)
+                self.assertIn("override_app_version=True", str(caught.exception))
+                self.assertIn("matching Bloks hash", str(caught.exception))
+                self.client.bloks_caa_login.assert_not_called()
+                self.client.bloks_caa_login_prepare.assert_not_called()
+                self.client.pre_login_flow.assert_not_called()
+                self.client.login_legacy.assert_not_called()
+                self.client.private_request.assert_not_called()
+                self.assertEqual(self.client.device_settings, settings["device_settings"])
+                self.assertEqual(self.client.get_settings()["uuids"], settings["uuids"])
+                self.assertEqual(settings, original_settings)
+                if mode != "fresh":
+                    self.assert_session_cleared()
+                    self.assertEqual(self.client.authorization_data, {})
+
+    def test_saved_session_without_app_hash_can_still_be_reused(self):
+        self.client = Client(settings=self.old_app_settings(), private_transport="requests")
+        self.assertIsNone(self.client.bloks_versioning_id)
+        self.saved_session()
+        self.client.account_info = Mock(return_value=object())
+        self.client.bloks_caa_login = Mock(side_effect=AssertionError("Unexpected CAA login"))
+        self.client.pre_login_flow = Mock(side_effect=AssertionError("Unexpected legacy preflight"))
+
+        self.assertTrue(self.client.login("example", "password"))
+
+        self.client.account_info.assert_called_once_with()
+        self.client.bloks_caa_login.assert_not_called()
+        self.client.pre_login_flow.assert_not_called()
+        self.assertEqual(self.client.authorization_data["sessionid"], "stale")
+        self.assertIsNone(self.client.bloks_versioning_id)
+
+    def test_app_override_restores_caa_profile_and_preserves_device_uuids_and_proxy(self):
+        settings = self.old_app_settings()
+        original_settings = deepcopy(settings)
+        proxy = "http://127.0.0.1:4321"
+        self.client = Client(settings=settings, proxy=proxy, override_app_version=True, private_transport="requests")
+        self.client.bloks_caa_login = Mock(side_effect=self.caa_success)
+        self.client.login_flow = Mock()
+        self.client.pre_login_flow = Mock(side_effect=AssertionError("Unexpected legacy preflight"))
+        self.client.private_request = Mock(side_effect=AssertionError("Unexpected private request"))
+
+        self.assertTrue(self.client.login("example", "password"))
+
+        supported_profile = config.APP_SETTINGS[config.DEFAULT_APP_VERSION]
+        for key in ("app_version", "version_code", "bloks_versioning_id"):
+            self.assertEqual(self.client.device_settings[key], supported_profile[key])
+        self.assertEqual(self.client.bloks_versioning_id, supported_profile["bloks_versioning_id"])
+        for key, value in settings["device_settings"].items():
+            if key not in {"app_version", "version_code", "bloks_versioning_id"}:
+                self.assertEqual(self.client.device_settings[key], value)
+        self.assertEqual(self.client.get_settings()["uuids"], settings["uuids"])
+        self.assertEqual(self.client.proxy, proxy)
+        self.assertEqual(self.client.private.proxies["https"], proxy)
+        self.assertEqual(self.client.public.proxies["https"], proxy)
+        self.assertEqual(settings, original_settings)
+        self.client.bloks_caa_login.assert_called_once_with(verification_code="")
+        self.client.login_flow.assert_called_once_with()

--- a/tests/regression/test_login_diagnostic.py
+++ b/tests/regression/test_login_diagnostic.py
@@ -37,8 +37,9 @@ def response(request, status, body, content_type="application/json"):
     return result
 
 
-def failing_login(monkeypatch, caa_body, content_type):
-    client = Client()
+def failing_legacy_login(monkeypatch, caa_body, content_type):
+    client = Client(private_transport="requests")
+    client.login = client.login_legacy
     client.private.trust_env = False
     client.public.trust_env = False
     client.caa_aac = '{"aaccs":"synthetic-context"}'
@@ -75,10 +76,10 @@ def failing_login(monkeypatch, caa_body, content_type):
         (b'{"message":"limit","status":"fail"}', "application/json", "dict", False),
     ],
 )
-def test_captures_original_and_caa_before_last_json_is_overwritten(
+def test_captures_legacy_and_caa_before_last_json_is_overwritten(
     diagnostic, monkeypatch, body, content_type, body_kind, empty
 ):
-    client, calls = failing_login(monkeypatch, body, content_type)
+    client, calls = failing_legacy_login(monkeypatch, body, content_type)
     previous_logging = logging.root.manager.disable
 
     report = diagnostic.diagnose(client, "synthetic-user", SECRET)
@@ -98,6 +99,73 @@ def test_captures_original_and_caa_before_last_json_is_overwritten(
     assert "private response" not in json.dumps(report)
     assert logging.root.manager.disable == previous_logging
     assert client.private.hooks["response"] == []
+
+
+@pytest.mark.parametrize(
+    ("error_type", "exception_type"),
+    [("bad_password", "BadPassword"), ("rate_limit_error", "RateLimitError")],
+)
+def test_default_caa_captures_one_request_and_preserves_sanitized_native_error(
+    diagnostic, monkeypatch, error_type, exception_type
+):
+    client = Client(settings={"session_retry_total": 0, "request_timeout": 0})
+    client.private.trust_env = False
+    client.public.trust_env = False
+    client.caa_aac = '{"aaccs":"synthetic-context"}'
+    client.pre_login_flow = Mock(side_effect=AssertionError("Unexpected legacy preflight"))
+    client.login_legacy = Mock(side_effect=AssertionError("Unexpected legacy login"))
+    client.password_encrypt = Mock(return_value="#PWD_INSTAGRAM:4:1:synthetic")
+    client.bloks_caa_login_prepare = Mock(return_value=True)
+    client.login_flow = Mock(side_effect=AssertionError("Unexpected success finalization"))
+    calls = []
+    previous_logging = logging.root.manager.disable
+    previous_handler = client.handle_exception
+
+    def send(request, **kwargs):
+        calls.append(request.url)
+        assert calls == [CAA], "Default login must submit credentials once through CAA"
+        assert request.method == "POST"
+        body = {
+            "message": SECRET,
+            "error_type": error_type,
+            "status": "fail",
+            "username": SECRET,
+            "challenge_context": SECRET,
+            "authorization_data": {"sessionid": SECRET},
+        }
+        result = response(request, 400, json.dumps(body).encode())
+        result.headers["Set-Cookie"] = f"sessionid={SECRET}"
+        return result
+
+    # Patch the selected adapter so this exercises Client's default transport
+    # and the real response hooks without sending a network request.
+    monkeypatch.setattr(client.private.get_adapter(CAA), "send", send)
+    monkeypatch.setattr(
+        client.public,
+        "send",
+        Mock(side_effect=AssertionError("Unexpected public request")),
+    )
+
+    report = diagnostic.diagnose(client, "synthetic-user", SECRET)
+
+    assert calls == [CAA]
+    assert report["outcome"] == "error"
+    assert report["exception"]["type"] == exception_type
+    assert report["exception"]["error_type"] == error_type
+    assert report["last_json"]["error_type"] == error_type
+    assert [(item["endpoint"], item["http_status"]) for item in report["responses"]] == [
+        ("caa/send_login_request", 400),
+    ]
+    assert report["responses"][0]["json"]["error_type"] == error_type
+    assert SECRET not in json.dumps(report)
+    assert logging.root.manager.disable == previous_logging
+    assert client.handle_exception is previous_handler
+    assert client.private.hooks["response"] == []
+    assert client.public.hooks["response"] == []
+    client.bloks_caa_login_prepare.assert_called_once_with(username="synthetic-user", domain="b.i.instagram.com")
+    client.pre_login_flow.assert_not_called()
+    client.login_legacy.assert_not_called()
+    client.login_flow.assert_not_called()
 
 
 def test_response_summary_never_copies_untrusted_strings(diagnostic):
@@ -140,7 +208,8 @@ def test_native_challenge_fields_remain_useful(diagnostic):
 
 @pytest.mark.parametrize("custom_handler", [False, True])
 def test_stops_before_automatic_challenge_requests_and_restores_handler(diagnostic, monkeypatch, custom_handler):
-    client = Client(settings={"session_retry_total": 0, "request_timeout": 0})
+    client = Client(private_transport="requests", settings={"session_retry_total": 0, "request_timeout": 0})
+    client.login = client.login_legacy
     client.pre_login_flow = Mock(return_value=True)
     client.password_encrypt = Mock(return_value="synthetic")
     original_handler = Mock(side_effect=RuntimeError("must not call user handler")) if custom_handler else None
@@ -170,7 +239,7 @@ def test_stops_before_automatic_challenge_requests_and_restores_handler(diagnost
 
 
 def test_main_saves_private_settings_and_sanitized_report_after_failure(diagnostic, monkeypatch, tmp_path, capsys):
-    client, _ = failing_login(monkeypatch, b"", "text/html")
+    client, _ = failing_legacy_login(monkeypatch, b"", "text/html")
     client.private.cookies.set("synthetic_private_cookie", SECRET)
     factory = Mock(return_value=client)
     monkeypatch.setattr(diagnostic, "Client", factory)

--- a/tests/regression/test_private_transport.py
+++ b/tests/regression/test_private_transport.py
@@ -7,10 +7,10 @@ from requests.adapters import HTTPAdapter
 from instagrapi import Client
 
 
-def test_default_private_transport_does_not_import_optional_dependencies(monkeypatch):
+def test_explicit_requests_transport_does_not_import_curl(monkeypatch):
     monkeypatch.setitem(sys.modules, "curl_adapter", None)
     monkeypatch.setitem(sys.modules, "curl_cffi", None)
-    client = Client()
+    client = Client(private_transport="requests")
 
     assert client.private_transport == "requests"
     assert type(client.private.get_adapter("https://i.instagram.com/")) is HTTPAdapter
@@ -21,12 +21,13 @@ def test_unknown_private_transport_is_rejected():
         Client(private_transport="unknown")
 
 
-def test_missing_curl_extra_has_actionable_error(monkeypatch):
+@pytest.mark.parametrize("kwargs", [{}, {"private_transport": "curl"}])
+def test_missing_curl_dependency_has_actionable_error(monkeypatch, kwargs):
     # Keep newly imported application modules cached for later mock targets.
     monkeypatch.setitem(sys.modules, "curl_adapter", None)
     monkeypatch.setitem(sys.modules, "curl_cffi", None)
-    with pytest.raises(RuntimeError, match=r"pip install instagrapi\[curl\]"):
-        Client(private_transport="curl")
+    with pytest.raises(RuntimeError, match=r"requires curl_cffi>=0.15.0"):
+        Client(**kwargs)
 
 
 @pytest.fixture
@@ -91,7 +92,7 @@ def test_invalid_transport_update_does_not_replace_adapter(curl_adapter_factory)
 
 
 def test_unavailable_transport_update_keeps_working_configuration():
-    client = Client()
+    client = Client(private_transport="requests")
     adapter = client.private.get_adapter("https://i.instagram.com/")
     with mock.patch("instagrapi.transports.create_curl_h2_adapter", side_effect=RuntimeError("Unavailable")):
         with pytest.raises(RuntimeError, match="Unavailable"):

--- a/tests/regression/test_private_transport_wire.py
+++ b/tests/regression/test_private_transport_wire.py
@@ -9,7 +9,7 @@ import pytest
 import requests
 from urllib3.util import Timeout
 
-curl_cffi = pytest.importorskip("curl_cffi", reason="install instagrapi[curl] for transport wire tests")
+curl_cffi = pytest.importorskip("curl_cffi", reason="curl_cffi is required for private transport wire tests")
 pytest.importorskip("h2")
 pytest.importorskip("cryptography")
 
@@ -35,7 +35,7 @@ def lab(tmp_path, monkeypatch):
 
 @pytest.fixture
 def client(lab):
-    client = Client(private_transport="curl", tls_verify=str(lab.ca_path), request_timeout=0)
+    client = Client(tls_verify=str(lab.ca_path), request_timeout=0)
     client.private.trust_env = False
     adapter = client.private.get_adapter("https://localhost/")
     adapter.client.curl_options[CurlOpt.RESOLVE] = [f"{LAB_HOST}:{lab.port}:127.0.0.1"]

--- a/tests/regression/test_retry.py
+++ b/tests/regression/test_retry.py
@@ -63,6 +63,7 @@ def response_with_json(status_code, payload, url):
 
 def retry_client(total=2):
     client = Client(
+        private_transport="requests",
         request_timeout=0,
         public_request_retries_timeout=0,
         session_retry_total=total,


### PR DESCRIPTION
## Summary

Make a standard installation use CAA authentication and private HTTP/2 without constructor flags:

```python
from instagrapi import Client

cl = Client()
cl.login(USERNAME, PASSWORD)
```

- `login()` calls CAA directly, reuses valid saved sessions, and propagates native failures without falling back to the old password endpoint.
- Preserve the previous implementation as `login_legacy()` with the same arguments and existing legacy fallbacks. Transport remains a separate choice; `private_transport="requests"` is still available.
- Install `curl_cffi>=0.15.0` as a runtime dependency. Private HTTP/2 uses libcurl; neither a system curl executable nor Python `h2` is required. The optional `curl` extra remains for public browser impersonation.
- Preserve explicitly saved transport choices. Saved settings without a transport key inherit the constructor default. An unsupported old app profile without a Bloks hash fails before CAA requests with actionable migration guidance; `override_app_version=True` updates the app profile while retaining hardware and device identifiers.

This is the breaking 3.0.0 major release. The release version, changelog and migration guide are included. Related to subzeroid/instagrapi#2778 and subzeroid/instagrapi#2792. Paired PR: subzeroid/aiograpi#445. Implementation: [aiograpi commit](https://github.com/subzeroid/aiograpi/commit/f4362f8519e7fcf9f95ac86237f04a1af8c879a6).

## Test coverage and review

Covered direct CAA outcomes, saved-session reuse and expiry, verification context and codes, relogin limits, missing app hashes, native errors, legacy compatibility, default transport selection, settings precedence, missing dependencies, and real TLS/HTTP2 traffic. Independent specification and adversarial code reviews passed; the legacy implementation was checked for unchanged behavior except its name and recursive entry point.

## Validation

- Local full offline suite: **871 passed, 3 skipped, 57 subtests passed**.
- Ruff, formatting, Bandit, pre-commit, strict documentation build, wheel/sdist builds, and clean normal installation passed.
- Clean installation selects curl without the optional curl extra, Python h2, or curl-adapter.
- CI now runs full offline regressions on Python 3.10–3.14, minimum/current curl HTTP/2 wire tests, and clean installations on Linux, macOS, and Windows.
- CI passed: **21 successful checks**; the branch-only documentation deployment was skipped.
- Fresh live sample: **10/10 CAA logins, 10/10 current-user checks, 10/10 saved-session restorations**. Exactly 10 password submissions, zero old `accounts/login/` requests and zero HTTP 429 responses.
- All **90/90 private responses used HTTP/2**. The existing public password-key helper remains unchanged; its expected HTTP 405 response supplied valid encryption-key headers.
- Live checks explicitly upgraded the app profile to the supported 446 profile while preserving each account's assigned proxy, hardware settings and device identifiers. These results apply to this ten-account sample.

## Documentation

- Added CAA migration guidance covering default login, explicit login_legacy(), saved-session and transport precedence, older-profile updates, verification failures, and installation requirements.
- Updated README, TOTP, transport guidance, and navigation; clarified Requests retry settings and the load_settings override_app_version option.
- Strict MkDocs build and changed-file documentation checks pass. Release metadata and migration guidance now target 3.0.0; historical release notes are preserved.
